### PR TITLE
fix: rename `OpenTracker` secrets

### DIFF
--- a/opentracker/secrets/sealed-opentracker-database-url.yaml
+++ b/opentracker/secrets/sealed-opentracker-database-url.yaml
@@ -2,7 +2,7 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   creationTimestamp: null
-  name: pl-tracker-database-url
+  name: opentracker-database-url
   namespace: default
 spec:
   encryptedData:
@@ -11,6 +11,6 @@ spec:
     data: null
     metadata:
       creationTimestamp: null
-      name: pl-tracker-database-url
+      name: opentracker-database-url
       namespace: default
 

--- a/opentracker/secrets/sealed-opentracker-jwt-key.yaml
+++ b/opentracker/secrets/sealed-opentracker-jwt-key.yaml
@@ -2,7 +2,7 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   creationTimestamp: null
-  name: pl-tracker-jwt-key
+  name: opentracker-jwt-key
   namespace: default
 spec:
   encryptedData:
@@ -11,6 +11,6 @@ spec:
     data: null
     metadata:
       creationTimestamp: null
-      name: pl-tracker-jwt-key
+      name: opentracker-jwt-key
       namespace: default
 


### PR DESCRIPTION
Rename the secrets used for OpenTracker as the pods cannot find them.
