### PR TITLE
infra: add redundancy

### DIFF
--- a/blackboards/deployment.yaml
+++ b/blackboards/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: blackboards
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: blackboards

--- a/opentracker/backend/deployment.yaml
+++ b/opentracker/backend/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: opentracker-backend
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: opentracker-backend

--- a/opentracker/frontend/deployment.yaml
+++ b/opentracker/frontend/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: opentracker-frontend
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: opentracker-frontend


### PR DESCRIPTION
Set a number of replicas for `blackboards` and the two `opentracker` images as the default number of replicas is one. This means that if a pod fails for some reason, there will be a backup one to use for the time being and Kubernetes will spin up another image while the backup handles traffic.
