### PR TITLE
feat: automatically roll images for `blackboards`

### DIFF
--- a/blackboards/deployment.yaml
+++ b/blackboards/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: blackboards
-          image: alexanderjackson/blackboards:20220109-0950
+          image: alexanderjackson/blackboards:20220109-0950 # {"$imagepolicy": "flux-system:blackboards"}
           env:
             - name: ROCKET_SECRET_KEY
               valueFrom:

--- a/blackboards/image-policy.yaml
+++ b/blackboards/image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: blackboards
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: blackboards
+  filterTags:
+    pattern: "^(?P<date>[0-9]+)-(?P<time>[0-9]+)"
+    extract: "$date$time"
+  policy:
+    numerical:
+      order: asc

--- a/blackboards/image-repository.yaml
+++ b/blackboards/image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: blackboards
+  namespace: flux-system
+spec:
+  image: alexanderjackson/blackboards
+  interval: 1m0s


### PR DESCRIPTION
Add an image repository and policy for `blackboards` to allow Flux to automatically pull new versions and roll them in.
