### PR TITLE
feat: add `cert-manager` repository

### DIFF
--- a/cert-manager/helm-repository.yaml
+++ b/cert-manager/helm-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  url: https://charts.jetstack.io


### PR DESCRIPTION
Add the `cert-manager` repository so we can reconcile it to the repository in the future.
