### PR TITLE
feat: add `cert-manager` release

### DIFF
--- a/cert-manager/helm-release.yaml
+++ b/cert-manager/helm-release.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  targetNamespace: cert-manager
+  releaseName: cert-manager
+  chart:
+    spec:
+      chart: cert-manager
+      version: "v1.8.0"
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: flux-system
+  interval: 1m0s
+  values:
+    installCRDs: true


### PR DESCRIPTION
Add a `cert-manager` Helm release type to the project that installs the CRDs and the latest version.
