### PR TITLE
ci: correct the working directory

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -10,6 +10,9 @@ jobs:
   terraform:
     name: "Terraform Apply"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -10,6 +10,9 @@ jobs:
   terraform:
     name: "Terraform Plan"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -56,8 +59,6 @@ jobs:
             \`\`\`
 
             </details>
-
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
Correct the working directory for `plan` and `apply`, as well as removing the tagging from plan messages.
