### PR TITLE
chore: remove dead records

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,31 +58,3 @@ resource "digitalocean_record" "opentracker" {
   name   = "tracker"
   value  = digitalocean_droplet.main.ipv4_address
 }
-
-resource "digitalocean_record" "webhooks" {
-  domain = digitalocean_domain.blackboards.id
-  type   = "A"
-  name   = "webhooks"
-  value  = digitalocean_droplet.main.ipv4_address
-}
-
-resource "digitalocean_record" "abs" {
-  domain = digitalocean_domain.blackboards.id
-  type   = "A"
-  name   = "abs"
-  value  = digitalocean_droplet.main.ipv4_address
-}
-
-resource "digitalocean_record" "sepl" {
-  domain = digitalocean_domain.blackboards.id
-  type   = "A"
-  name   = "sepl"
-  value  = digitalocean_droplet.main.ipv4_address
-}
-
-resource "digitalocean_record" "starling-webhooks" {
-  domain = digitalocean_domain.blackboards.id
-  type   = "A"
-  name   = "starling-webhooks"
-  value  = digitalocean_droplet.main.ipv4_address
-}


### PR DESCRIPTION
None of these records are being used internally by the server, so we might as well remove them from the state. `starling-webhooks` will likely be added back at a later date, once the project has been imported to Kubernetes.
