### PR TITLE
feat: add DNS record for `starling-listener`

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,3 +58,10 @@ resource "digitalocean_record" "opentracker" {
   name   = "tracker"
   value  = digitalocean_droplet.main.ipv4_address
 }
+
+resource "digitalocean_record" "starling-listener" {
+  domain = digitalocean_domain.blackboards.id
+  type   = "A"
+  name   = "sb-webhooks"
+  value  = digitalocean_droplet.main.ipv4_address
+}


### PR DESCRIPTION
Add a DNS record for the `starling-listener` project so that traffic can be sent to the server and recorded/orchestrated by the handler.
