### PR TITLE
feat: add `starling-listener` Kube definitions

### DIFF
--- a/kubernetes/apps/starling-listener/deployment.yaml
+++ b/kubernetes/apps/starling-listener/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: starling-listener-deployment
+  labels:
+    app: starling-listener
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: starling-listener
+  template:
+    metadata:
+      labels:
+        app: starling-listener
+    spec:
+      containers:
+        - name: starling-listener
+          image: alexanderjackson/starling-listener:20220501-2057 # {"$imagepolicy": "flux-system:starling-listener"}
+          env:
+            - name: DISCORD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: discord-token
+                  key: DISCORD_TOKEN
+            - name: DISCORD_CHANNEL_ID
+              valueFrom:
+                secretKeyRef:
+                  name: discord-channel-id
+                  key: DISCORD_CHANNEL_ID

--- a/kubernetes/apps/starling-listener/image-policy.yaml
+++ b/kubernetes/apps/starling-listener/image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: starling-listener
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: starling-listener
+  filterTags:
+    pattern: "^(?P<date>[0-9]+)-(?P<time>[0-9]+)"
+    extract: "$date$time"
+  policy:
+    numerical:
+      order: asc

--- a/kubernetes/apps/starling-listener/image-repository.yaml
+++ b/kubernetes/apps/starling-listener/image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: starling-listener
+  namespace: flux-system
+spec:
+  image: alexanderjackson/starling-listener
+  interval: 1m0s

--- a/kubernetes/apps/starling-listener/ingress.yaml
+++ b/kubernetes/apps/starling-listener/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: starling-listener-ingress
+  namespace: default
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - hosts:
+    - sb-webhooks.blackboards.pl
+    secretName: starling-listener-tls
+  rules:
+  - host: sb-webhooks.blackboards.pl
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: starling-listener-service
+            port:
+              number: 80

--- a/kubernetes/apps/starling-listener/secrets/sealed-discord-channel-id.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-discord-channel-id.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: discord-channel-id
+  namespace: default
+spec:
+  encryptedData:
+    DISCORD_CHANNEL_ID: AgCYd94G7vuQGv0brtbVzek/bUISrux1TWF5EwhGp/q024n3439UMLZ3N6Ib4111IWbPTwScrkxJDIZMFFTbbrxzxcEA7OxIIoe41wYe8MyfYGlDgvo120JVUDUl0UOkMTBDUKzVc9XOcMZVqt/F8muqBc7oRCkqh7c5GuQFSAHV3kn3Uaf+doCWvPX1xobtJarGvrO4OSWSq95YR68wwGXLrRniIfV2nI1Kcw6xFlqctiB9lYAVBYB51fzZkTQpVvvubqPG7geZ9PgqNzpIFHjjptNbeKtzY+fZwD5VPbSOluCoNktNSRf/lf54/vWDp1qVNkvjBL3/ONJObhmhpjk1Jri3E4eCpntr4EWzVBpjrtG+xuk+VJ9V65q+igJpggspnymOcD8XaupX1UgHkEYJzFEv3NoUZ5yQGrRh6Tc7wA2naB5Mk6yVAs4x1LrxX9gHUVEHBDGZ+91XmOVqhnyh7u1AxpGJgM4sj18b4/9yTkaTfZhlBRHGvFOOnd5ZTn0+ZGrcp4KERGUDK8wxURqX8QCnl6Wc58RtLgp4CEEWIyPmcOdOyuHg4TUpWrr7qHGqZytG/rjfZsKiNxr8UMWNd1HJGKhZMmfNyaO0J/8y58HPOiKvnoXYVUQhsdszK+AFeLXWIyOmywLMyGpGFh3uPAfIHChBniRv5zmoORvXenErgy6p2uC5J2s7ban+s4sNuyqaLxbghymDqok6Xky3Dlc=
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: discord-channel-id
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-discord-token.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-discord-token.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: discord-token
+  namespace: default
+spec:
+  encryptedData:
+    DISCORD_TOKEN: AgACpSBjNJp4prfan0TsldACus3u2CpUWUUtpryc5Hlw7FEaid7O5p0e81QOiqnZmP1ioyLoPZvSmEcC+KplaIXjmlS9dZ3nYNvh16uyUCgKa2RnbBS2D4Kb9ZOFc0Gd8YYoex+oIlGl1+7HGeYEQvqhnRS7PdoE31M19xfa9VLdhbSFo4zDGRSnkuxSafvi759VnOters3WBOMnIfOxI0QOLA4CkP6mgc2UCFEUMwDhiySW+YKwnWnsK6Ako7PJCLUtDe+bmU2meC0vqcuob6tRC040R32i9nQ1bbCUjZpswp8VRrS46DfgLeFWwJgclmbBoyuHCjYZOF5mj7fawrEUfWnkbsg+DCKnLcgnJSZ9fcosG7HUbi0Q7V21DCVNPhtXBdXogh3YWyegkkMBkPBVgtzkLyvFEKRieUwy6/ITvLOzQcfn1c0Ftf2B8DcJVebvHzwPP2GQqxhK5NB1ucBTAZoAQbY3WTZ+saaX2rKwu2roYr1JpPIQz1BuPFv/wpYotFZ3/dH0MuYbELDYomF0HyOvKCSMFYoZLOWl0e2Mx8ocemmuOWvroijaa4FtLkjKkjuEkDxWfMUpwrXUaoh7L86JfjSGSLq2Qej7XaNBdZHQbcNVr9loSg6PM9WLo7rYCApXIZgZxqDQHalE+3N3L7HQAL2LEsC4dRq1zyCkX/xWewmZQ5ag52L9uMjd2N6cf7S/Ggt1EVHCpYzhdG7TjUzBS/ULQF1FJifRPLNrC4kVsanWmaFGwJDB/TSY3RVjat4e6EhZviEVZw==
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: discord-token
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/service.yaml
+++ b/kubernetes/apps/starling-listener/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: starling-listener-service
+spec:
+  ports:
+  - port: 80
+    targetPort: 4000
+  selector:
+    app: starling-listener


### PR DESCRIPTION
Add Kube definitions for the `starling-listener` service, allowing it to start up on the server, receive automatic updates via `flux` and handle traffic with SSL certificates.
