### PR TITLE
feat: add additional record

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -65,3 +65,10 @@ resource "digitalocean_record" "starling-listener" {
   name   = "sb-webhooks"
   value  = digitalocean_droplet.main.ipv4_address
 }
+
+resource "digitalocean_record" "starling-webhooks" {
+  domain = digitalocean_domain.blackboards.id
+  type   = "A"
+  name   = "starling-webhooks"
+  value  = digitalocean_droplet.main.ipv4_address
+}


### PR DESCRIPTION
Add an additional DNS record at `starling-webhooks.blackboards.pl` as this is where webhooks are currently being sent and access has been lost to the developer account to update this for now.

This will be deleted in the future once traffic has been diverted to the other one.
