### PR TITLE
feat: add secrets for `starling-listener`

### DIFF
--- a/kubernetes/apps/starling-listener/deployment.yaml
+++ b/kubernetes/apps/starling-listener/deployment.yaml
@@ -29,3 +29,46 @@ spec:
                 secretKeyRef:
                   name: discord-channel-id
                   key: DISCORD_CHANNEL_ID
+
+            - name: PGROOTUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-root-user
+                  key: PGROOTUSER
+            - name: PGROOTPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-root-password
+                  key: PGROOTPASSWORD
+            - name: PGROOTDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-root-database
+                  key: PGROOTDATABASE
+
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-user
+                  key: PGUSER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-password
+                  key: PGPASSWORD
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database
+                  key: PGDATABASE
+
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-host
+                  key: PGHOST
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-port
+                  key: PGPORT

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-database.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-database.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-database
+  namespace: default
+spec:
+  encryptedData:
+    PGDATABASE: AgCDfaoHWcCc8gnosE52A4b2ztIm5NzQatfGdOdr2GAoBEiV0nHun6bgxZOUBGCjiBLdketoaUOxj43z6nWbIJTfweaGeECjKgHWhvicGGJGkqsEfEWy6Xe8G/dluw8JHEJ9fzdzHEIt7uRGuIo/vxrx8cahNFBxpR6ZG9ecgpuu/UBwOqsNzHf2B4BieDCC/9cEeKIwNa6It8OMBq1SKdBRvofUrtyyRfCNIxGw+CQQFmzYTe7KSm4menhjhLJ7h8FSZI6KOYI5BN+wAO5r5nBtUm974sT5p2OPJ1OF3qLS4PG6SkNuSllOaBMouNd/htP7+slHUr9qTwXkAF6QZHtK25fZBx5Faq6EhaH9WgoPfu0V9KocfGYsfvc7OrFUxp0+TM+8W9hmNVQAD8DNQrSTAhIEKcIFSfKLYXFnfZiNOQ9Vll0qE5XK0MjvNe97p1je0cKxIJnBQPFhdQqVi3tUZ084SizxJSIQ17VLRDs6t4z9wbSVF2aCPSXhV11wD1adoPCV71QfNBKlEaAwWHKuy8qp7Gro9rUrI0maJAgmXmZ2Vn706VSWpiPEYNFGr9tqAJHb0nk2h3F8RN45Gno5dyQMy35+t/nNv2Xg1fjFxeRU8dA+X2iqmxVzw65YdDoYnsI+/ZX6Sqtop/Oif1kHxY5RTXF7kNstv9zw6JPLet8/vIG3WI3NlyM2F9fnZBuxVdbcNfhk21H7hogT/FS4
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-database
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-host.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-host.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-host
+  namespace: default
+spec:
+  encryptedData:
+    PGHOST: AgA6Yx/sLyNAaoAN8Qwwju1bqvSP2AP4FEQYJ7HpLLHg1PL5fR0t6eI6LdjEox1m3PRFNXrSa0GoASG0PDmqQU1R9PwQ03/iiIJhBUzt/77GMxNO8/s6o7P7339RuJBknlVTMj2UhQJ7fRBM/91EA/nD+96GAfz+AcZ2+gsGiRhgD098EK+6e6rX8cnXMgBFd2ynieb1guHDjwbPCIxnK9TByBcE28+573xr8k9bjAiRN+Lo6y6oGoaH8YhTJXscuBhsW35+ujzH7TgTj6f/M4gQWStWsE0kB9y7otymiRnGlGv+678I5zyitcVZosNGEYJdpKUikb50fWPcuSWGQ9TeorQW6Hsp80ms5AsmgLpO6WOwkwQE0E+4KqMviBMXKCj5g8s36OoMI4/+bNNtcfFOP+BD3pOiyBzP2wvV+xH5lTIwQNWhhjnTwXAOcBjyPM07tJGdErBZPV9ncLbCGeHQZuKqjo0F5/erAQfnbcac3xh2RpVF99mE1Ks4J1RuTA6mr3wRnkN7M90M/xvDx9iVBiPl6AZ35WekCF9X41FavPQvyp405W5BhJr0EMwVBjzuu1CceOw2nNsyZ89KiyH6EQXJUiPozwVmcpqROAf06z7tvNaXQDXdXcGmtY/qQElvRcg+0gwab2oLvgSgEnbD6f+nhnvg1ETqgNOeoGW96YTD4bI5Q6gFmIzp4ggyf+4K6+hVD6yAq3eJ5Yc7hj0OBG46dMJFb/hNn+64KB5yEQTtzRhurgTgMWY=
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-host
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-password.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-password.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-password
+  namespace: default
+spec:
+  encryptedData:
+    PGPASSWORD: AgA285+fmLv4XDo8yaX0P9H0hyR9cILCw97fkgJEyafbKnFIo7hjvfZwr7FQ94Ua+3ty7fYlC8HkxmBfG/+YPZYi4E9h73sSYzcLaYV8vthSHcgbI6h7I+pe2veC4CQ9b76BcSDFPJK5Ig9EPe1jPlMB0o4c0pjVBR0kJKShhhF1UbyYpdJ294oZYYf283bSJFWGQad7ewq/53ixZ5WFU0okrYwu1NVU74DCZ/H9rUahGksRx3V06AUBx5SoHW/fc8O1MhuJC5H9JVN02/z2cInTYzW4JgSU0oYU7S3q5fQyPkSO/kS+cKueT7oDm3At5j9MclMlOqvnXkj/Yv3MAgKqqSJRipxhQrVvalhG6KD/2QCmZ/YPK0pnCpn8zm8pEoZ6aR9YtiUThcY32yVyM2e4w5lV1AAmeriW6oWzHyw7AcYm0WQlZwrv4wJCvEo4Iiy5hTi/5GMWRAldxIFmv0B633c8Y1V2rKa7pD/Dms1EQZA0XmSwcXYqgZBgbyXVl7shIGy5Nb3mTkOeTja1D5OTARtgn71tjDRcACm8Qs49WeCwA4/wiygsfz6ecZHbViTo8f2XhFsN0vGMGvmJz+AAw4WaCfvz7EY5Glq552QxlSgrHHjpZNJzGKdbIEwWct+jKrEqh1E0wfn8XtwB+hsG0RBfjGDSOdRla7sRgg+Fulo/Vr3v8Q/luI+TGjJoGNg+IeTzqTlA96yr/4oVXL3ItdiXG6wz/+q4rW65tA==
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-password
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-port.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-port.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-port
+  namespace: default
+spec:
+  encryptedData:
+    PGPORT: AgBM8Wt9HVaNAwGXpknAPRKaRFddqvy9YXMfjLY7Og4N4MYaAT8B3bX2PBiieukFTNKGTqFv9g7+EOOxAgQqwMdiiiNy9+R3TWh0aRhdEXnGnaT3+uCRkblpsAJJKEHib7aius1eGBIg9r+S2MFh/qrOAukzeb6pOUOQ2XcQztdUn3A30nfuz2W7UVy3kUVcoGAPNVZh4TzQxQkdOzGQYrMZbmzc/YEn2VsgYGNIIywptuOPLX+1kRKUbHaqmXqULod0Y+4QoqBcQDs7jDWOjqmskFfHL4qVzUVVFp/ZXZ2/RTb5tPM8Fnw6CqM3fGJe1flHfEyGNeULTffcurPExQP4sMzlNLEjTYjPn7CxcfoGtI4UBAKLqCiD2cHsLeiVgN2b1T841zwknfn2gcGCgwsbNBzOD0VOm/dLcL+YejBxoSwnJajqrvdSpZOK/kD6kxfgegHEomMIspwr9LrxLoN0k3r9e3JYCbkXPnhMv8R70+SKcmYiRtwTAnFQoTdnmbz4dySp8JjsSdXN4NHvYCduNHJ8DZqHGRX416uTuPJprJKkk2FYOFNJbMYgcHoq1gVtM/k5I7I1kmLm5pwt+QDAuLWU5ubP2IVcOZw6UGk5vrlVVU4a6CxD79LHhvrELBWu7HyGJHDNRNALVi0guKy0k7Go6OZ4yYX4HNAwyOtCStbb0yydys4rekKYyQMAlnFa/R+5
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-port
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-root-database.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-root-database.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-root-database
+  namespace: default
+spec:
+  encryptedData:
+    PGROOTDATABASE: AgCDKOaWd3zLsOfLjxo2268Ysc3UBCNwiB8pux2JAJRGOpnz0NwNSafAUVSrnmianul7dcauNoEL+vL6ukucGmyAxXhWGN5WnAOcE2Krv7tcdax0tx+RD31GoiQvc5y5qHSsyuQyefSSxRKr/Q34o4VhZuLlA/cTPzGDKFKFXQ/92aFb4rE1cFcnv1yPpwZ/IUVpELYVMdeuUN7Mini/aQ7RVihNc9RficevrHPKDIcDVLmfgCLQbE+rV7YM+9Bdb1PuhaAwqFivvtXsWgfO3RVJrRxez5Di08jxSAm/BNNFz4eIti2oJKpRd9lUsbWPSyLJXOEmVFTbfnx26UD15gCRBs1QQiSG0tGCcwBW/ywMZNorpBUhaxhHIX1O4tl3fL+zEZgu9QILubkIrUMKkrYQR/OjsK3AjIx5qJlGrJDS10ukkGZstCWHjcOTgHreGzwGIfFQ+zvhkzJJKXvpb4ejs4LM7oDfXab0yB6usOxswCwklQzSPlHrvSVR4szHdcBI1UedeSwaG3tbf6bhLUdByxHjmB5KAj1Oai8449PvOWOCXeS67TQIGALK7ceE1S5O4oY4WWKIZrOyaUBjRa45D9lsBwzwWEmZdF2/fyIM722yospJGMZDk1xVQBXMV527huV/zP0Fsx4+ChiyGnQfJUPBAgfTv5nxrmv54j1v3Nx7zlAx1tns+U3ov+hz7iTZB9AxZfwTng==
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-root-database
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-root-password.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-root-password.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-root-password
+  namespace: default
+spec:
+  encryptedData:
+    PGROOTPASSWORD: AgBO7hi3SmXlX5u6gds33UODuTeNCmV4m4Q4ht40S9eBAlmjaoP3Gkc0BeS66qtDgyIxodcWbC9Ms1YKvj1ewx4iPQEx/OZb4Fd6Eyq6D+UDyYyj4cTdTjfJjAS3WMascBCVA3Lyq+gbx+mTbIO32CC/JIq5ij0imVf2LBTk7j6nBfpAUG23Uy2n1ladVvy60uRIckRN3Ng0MFQqGDe/1iCc0/jLeXqnZZc8g+X3Ne7jvtGCEMmfYfHTsbHNeSLvNV2GPvMURk1JoCsXIKjGzsjYDk8ZklKc9Tg13Amlq+HUp/SeI+t8VIQ6zmcqTVS6bv940E/L0aHM+j/CJxPYRTlxxz+o13pFG3BlW6k4QqBXCSkcltyCQqE4+DFpQJ96rkNLsWR8DhOjLAn4ds6Og9zvLQCOdURsOAmEkzqVElEoVV6v42gdbzO/9AoXve3Cg7tLG7pWdYklQR62To6y8BwvebhrapVXbY0t6Xm4XZccz8PkMwGvVILR2oWpSBOfX+y92RhdKJ15XeioPPUGFGFPtxBGFfvK0IcXA2aFCLs3BwL5Og2msukYTGYdJxFSabw5XROIJGGN/vzuozvopVLVX4eU+JPLodUc0WAq4n50Np3h7VEwlnk4Tp2+wtVmv+LvT9fhqTiIJFeFh4F+ymHbGL+s5YAktqfAQ8ROkVL2HDOW5dBtaLxO8EpkVmF/So3XWsfdTDVxycaAW0fnhuhinVTx2EueKYoY5L0GqytcRcg=
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-root-password
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-root-username.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-root-username.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-root-username
+  namespace: default
+spec:
+  encryptedData:
+    PGROOTUSER: AgBAN5sHS89itB+0m493RBKAyJ1v+QPodDiUBnKbaW1qgkXbkzmFz6JgYrwR7BvqTJKO098NqO13RlmAi80WirVNM8SNBO17ILmyMu7KNoorCvJQgzimVy+OYCVcyuPZ+up90b42UgolBDlHjhtsMuU5N/UfqWcM45hqmxIs+M5vPN3Bgzp41TnzFp4oBxSp+AwBAxYfdt/vF3uVZA/H3Dv6FIneY8tY88zPqETwW75CilBIzRUrM0hqji2GTN6xX7lIzMYN0dct2rA9T78viSsg8QNDN0av+/DYzlZ3LYHgfDJK6f+MTDLLDSRBBXlp3Q+kgHt1RzzeqSW1w3JyB+Bt50iEiKOO4gJETvzLDz27xdvj/ZdQnvm1uGaahlNOIo4Se2eflRo+/wXHS+W602ipPRaG8v8kFd1txDV/LPBBuFEBpZrMUKCWLGE5c2APVIekTbSDuJvM+3I46FDAbb1AOsG/FA1NCBWGYiEuooMFpDCwGJ0ctct1asCMUv2qptqob+uu120vaRkBEYK1Ax4NNS8wspCpnfg9vZpYekJpY9t3ovkoE78Cu6iYiWQ1MyWma/kd8n5Px6K43XU4yxsLcC98bi+KdF42SKwVo3kzKSxfE2de/fD5zuoSkWwGvK4zgtXTIZbBZOuUDY3meQ+CTp2NmZmMz8Ki9JuV3I4VQQDUjbvdzta8yl5WGpszhkZ1c8tc
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-root-username
+      namespace: default
+

--- a/kubernetes/apps/starling-listener/secrets/sealed-postgres-user.yaml
+++ b/kubernetes/apps/starling-listener/secrets/sealed-postgres-user.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-user
+  namespace: default
+spec:
+  encryptedData:
+    PGUSER: AgB9IfBLKwmSBDilhGVQ0ufb2N5W4evOFRNX7ezT47Fz00ZPdFukh7S+aQzz4HE9L5XQ6Nyubd9AzJHAWa5X87+G0UenJrOPqBGGxwmNj9WC4YYuyzlBz7KS3Z919UXLd9Xr6nG8qjB5+R4eYqiKnFWdCXKZSbf/ZnDOq0AkunxHyN+dIgJbOx5X8ivIhuuwZOIJXd3qKsf/SOhKo8S9ILdfhKpEUVBHpZpvt/29AYkSyZ3DmEq7FI+mIr5Iyw7zq7Wuv2bSMpR0NECUxKm5jR6muDvoYPzx+yYQDCDNZsU7MjVf+v7Ygcj7/FNyqz1JayGFo/RrGggqHU0e8E6wjQsaiD/jPOOYFuYtlgtAU74SkB485PPcN+bRYz60ApcFHteiOdTjrlDm679WGsqPAppJhG14iBxvevuEuC1Z+cEKBMLh1jYJ0PpUf+cGJNN5u4A6n4jDtMK3aj+3h1BVAOU8tsdqQM5K8aLQtOGwaG5vVa9ER6E1qDN2LYgzlC9wn7G+f+rytremc1dkxzdANz4/uehw/tvDNqgI67hrEySJicluXq4ikVrkXuBOl9+3ebeb96E4SCqVv3ABCFM30hJIahTi3lvQhFjcpnGbaaHKQyTGLoLQ9mmB7ImmuWjuB/vpMAlcdA0Qt0uMUiKOsvPHmMZNtAOO830alB//86c4nRWR4/15m/0N8CowVU/iS9bm7YTDy3zBq5xlMr/3a7dSqB+t+w==
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: postgres-user
+      namespace: default
+

--- a/kubernetes/scripts/create-sealed-secret.sh
+++ b/kubernetes/scripts/create-sealed-secret.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Sample usage: ./create-sealed-secret.sh <public_certificate> <name> <key_value_pair>
+
+cert=$1
+name=$2
+key_value_pair=$3
+
+# Create the secret itself
+
+kubectl create secret generic $name --from-literal=$key_value_pair --dry-run=client -o yaml > ${name}.yaml
+
+# Encrypt it using `kubeseal`
+
+kubeseal --cert $cert -o yaml <${name}.yaml >sealed-${name}.yaml
+
+# Delete the unencrypted version
+
+rm ${name}.yaml


### PR DESCRIPTION
Add secrets for `starling-listener` to allow it to bootstrap its database on startup and then connect to it in future.

Add a script to allow for easier creation of secrets.
