### PR TITLE
fix: rollback `opentracker` backend

### DIFF
--- a/kubernetes/apps/opentracker/backend/deployment.yaml
+++ b/kubernetes/apps/opentracker/backend/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: opentracker-backend
-          image: alexanderjackson/opentracker-backend:20220524-0624 # {"$imagepolicy": "flux-system:opentracker-backend"}
+          image: alexanderjackson/opentracker-backend:20220522-0747
           env:
             - name: DATABASE_URL
               valueFrom:


### PR DESCRIPTION
The backend was updated to use `axum`, which seems to not be agreeing with allowing requests in for some reason. Before we investigate more, let's just rollback and add some health checks so this can't happen again.

This PR:
* Rolls back `opentracker-backend` to a working version
* Removes the image policy so Flux doesn't re-bump it
