### PR TITLE
revert: break the `opentracker` backend again

### DIFF
--- a/kubernetes/apps/opentracker/backend/deployment.yaml
+++ b/kubernetes/apps/opentracker/backend/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: opentracker-backend
-          image: alexanderjackson/opentracker-backend:20220522-0747
+          image: alexanderjackson/opentracker-backend:20220524-0624 # {"$imagepolicy": "flux-system:opentracker-backend"}
           env:
             - name: DATABASE_URL
               valueFrom:


### PR DESCRIPTION
Revert the changes made to rollback the `opentracker` backend so we can do some testing of the changes.
