### PR TITLE
fix: update port forwarding

### DIFF
--- a/kubernetes/apps/opentracker/backend/service.yaml
+++ b/kubernetes/apps/opentracker/backend/service.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8000
+    targetPort: 3025
   selector:
     app: opentracker-backend


### PR DESCRIPTION
The port for the service is incorrect, as the `axum` server binds to 3025 instead of 8000. Pretty sure `rocket` wasn't binding to 8000, but stranger things have happened.
