### PR TITLE
feat: add health checks

### DIFF
--- a/kubernetes/apps/opentracker/backend/deployment.yaml
+++ b/kubernetes/apps/opentracker/backend/deployment.yaml
@@ -31,3 +31,9 @@ spec:
                   key: JWT_KEY
             - name: ROCKET_ADDRESS
               value: "0.0.0.0"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3025
+            initialDelaySeconds: 10
+            periodSeconds: 30


### PR DESCRIPTION
Recently `opentracker` went down (at least the backend portion) because the Docker image and deployment were not set up correctly. This caused the pods to start up healthy, but they were unable to serve any traffic.

This adds a liveness probe to the deployment, meaning Kube should wait for the pod to be able to serve traffic before terminating existing ones.

This PR:
* Adds a basic liveness probe to the `opentracker` backend deployment
