### PR TITLE
feat: add ingress for new domain

### DIFF
--- a/kubernetes/apps/opentracker/ingress.yaml
+++ b/kubernetes/apps/opentracker/ingress.yaml
@@ -10,9 +10,27 @@ spec:
   tls:
   - hosts:
     - tracker.blackboards.pl
+    - opentracker.app
     secretName: opentracker-tls
   rules:
   - host: tracker.blackboards.pl
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: opentracker-frontend-service
+            port:
+              number: 80
+      - pathType: Prefix
+        path: "/api"
+        backend:
+          service:
+            name: opentracker-backend-service
+            port:
+              number: 80
+  - host: opentracker.app
     http:
       paths:
       - pathType: Prefix


### PR DESCRIPTION
In #29, the Terraform resources were added to create a DNS record and some nameserver records for `opentracker.app`. This applied successfully and the DNS resolving site says the changes have propagated to some DNS servers now.

This PR:
* Adds an ingress rule for `opentracker.app` to send traffic to the frontend and backend service
* `opentracker` will still be available at `tracker.blackboards.pl` as this rule is still in place
