### PR TITLE
feat: bring Terraform in line

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,6 +10,11 @@ resource "digitalocean_project" "blackboards" {
   name        = "blackboards"
   purpose     = "Service or API"
   environment = "Production"
+  resources = [
+    digitalocean_domain.blackboards.urn,
+    digitalocean_domain.opentracker.urn,
+    digitalocean_droplet.main.urn,
+  ]
 }
 
 resource "digitalocean_droplet" "main" {


### PR DESCRIPTION
By adding the `opentracker.app` domain, Terraform has got confused about what resources this project has.

This PR:
* Adds the resources explicitly so Terraform doesn't try to destroy them in future
