### PR TITLE
fix: update AMI type

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,7 +22,7 @@ resource "digitalocean_project" "blackboards" {
 }
 
 resource "aws_instance" "main" {
-  ami           = "ami-0b5cc435ab27e968b"
+  ami           = "ami-09219966d6788d68e"
   instance_type = "t4g.medium"
 
   ebs_block_device {


### PR DESCRIPTION
The instance type is `arm64`, so we need an `arm64` AMI type instead of an `amd64` one.
