### PR TITLE
fix: update EBS device name

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "main" {
   instance_type = "t4g.medium"
 
   ebs_block_device {
-    device_name = "main"
+    device_name = "/dev/sdf"
     volume_size = 10
     volume_type = "gp2"
   }


### PR DESCRIPTION
EBS devices need to be proper paths, so let's mount this at `/dev/sdf` as that's _almost_ the default.
