### PR TITLE
chore: swap AMI

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,7 +27,7 @@ resource "aws_key_pair" "personal" {
 }
 
 resource "aws_instance" "main" {
-  ami           = "ami-09219966d6788d68e"
+  ami           = "ami-0a6b5206d1730bdce"
   instance_type = "t4g.medium"
 
   ebs_block_device {


### PR DESCRIPTION
The current AMI is using Flatcar, which is somewhat restrictive. Let's swap to a more standard AMI and see if we can connect to the instance.
