### PR TITLE
fix: add CIDR blocks

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,6 +55,7 @@ resource "aws_security_group_rule" "allow_inbound_ssh" {
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.allow_inbound_ssh.id
 }
 


### PR DESCRIPTION
CIDR blocks are required here so that we know where the rule applies from.
