### PR TITLE
test: alert on all deployments

### DIFF
--- a/kubernetes/shared/notifications/alert.yaml
+++ b/kubernetes/shared/notifications/alert.yaml
@@ -12,3 +12,5 @@ spec:
       name: '*'
     - kind: Kustomization
       name: '*'
+    - kind: Deployment
+      name: '*'


### PR DESCRIPTION
It would be useful to know when a deployment has finished, instead of when it is starting.
