### PR TITLE
feat: add second node

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -38,7 +38,7 @@ resource "digitalocean_kubernetes_cluster" "main" {
   node_pool {
     name       = "worker-pool"
     size       = "s-1vcpu-2gb"
-    node_count = 1
+    node_count = 2
   }
 }
 


### PR DESCRIPTION
Turns out there's plenty running on the base node, so we probably need a second one to spread the load a bit and actually install Flux.

This change:
* Adds a second node to the cluster
