### PR TITLE
chore: destroy managed cluster

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,6 @@ resource "digitalocean_project" "blackboards" {
     digitalocean_domain.blackboards.urn,
     digitalocean_domain.opentracker.urn,
     digitalocean_droplet.main.urn,
-    digitalocean_kubernetes_cluster.main.urn,
   ]
 }
 
@@ -28,18 +27,6 @@ resource "digitalocean_droplet" "main" {
   region     = "lon1"
   size       = "s-2vcpu-4gb"
   monitoring = true
-}
-
-resource "digitalocean_kubernetes_cluster" "main" {
-  name    = "main"
-  region  = "lon1"
-  version = "1.25.4-do.0"
-
-  node_pool {
-    name       = "worker-pool"
-    size       = "s-1vcpu-2gb"
-    node_count = 2
-  }
 }
 
 resource "digitalocean_domain" "blackboards" {


### PR DESCRIPTION
It turns out that even with 2 nodes there's too much overhead to actually schedule anything onto the cluster, so it's probably not worth the difficulty.

This change:
* Destroys the cluster and removes it from the project
