### PR TITLE
feat: create tiny instance

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,6 +29,14 @@ resource "digitalocean_droplet" "main" {
   monitoring = true
 }
 
+resource "digitalocean_droplet" "secondary" {
+  name       = "secondary"
+  image      = "63663980"
+  region     = "lon1"
+  size       = "s-1vcpu-512mb"
+  monitoring = true
+}
+
 resource "digitalocean_domain" "blackboards" {
   name = "blackboards.pl"
 }


### PR DESCRIPTION
Just to get some applications up and running again, let's start a tiny instance and then load the Docker images and data onto it. This won't use Kubernetes or need to build anything, so the low resources might be alright.

This change:
* Stands up an instance of the smallest type
