### PR TITLE
fix: choose correct image

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,9 +31,9 @@ resource "digitalocean_droplet" "main" {
 
 resource "digitalocean_droplet" "secondary" {
   name       = "secondary"
-  image      = "63663980"
+  image      = "ubuntu-22-10-x64"
   region     = "lon1"
-  size       = "s-1vcpu-512mb"
+  size       = "s-1vcpu-1gb"
   monitoring = true
 }
 


### PR DESCRIPTION
This image isn't available anymore, so let's take the latest version of Ubuntu from the documentation. The size also isn't available in London (could choose Amsterdam or Frankfurt though) so choose the next one up.

This change:
* Specifies the image slug correctly
* Bumps the size as it isn't available in this region
