### PR TITLE
feat: add SSH access

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,6 +35,7 @@ resource "digitalocean_droplet" "secondary" {
   region     = "lon1"
   size       = "s-1vcpu-1gb"
   monitoring = true
+  ssh_keys   = [23928565]
 }
 
 resource "digitalocean_domain" "blackboards" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,6 +18,7 @@ resource "digitalocean_project" "blackboards" {
     digitalocean_domain.blackboards.urn,
     digitalocean_domain.opentracker.urn,
     digitalocean_droplet.main.urn,
+    digitalocean_droplet.secondary.urn,
   ]
 }
 


### PR DESCRIPTION
Need the ability to SSH into the instance, luckily Digital Ocean already knows about this key so we can just recreate the instance itself.

This change:
* Adds the key for my laptop to the instance to enable access
