### PR TITLE
feat: failover to new instance

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,7 +100,7 @@ resource "digitalocean_record" "opentracker-root" {
   domain = digitalocean_domain.opentracker.id
   type   = "A"
   name   = "@"
-  value  = digitalocean_droplet.main.ipv4_address
+  value  = digitalocean_droplet.secondary.ipv4_address
 }
 
 resource "digitalocean_record" "opentracker" {


### PR DESCRIPTION
The new instance seems to have some things set up now (ie. it is running containers, there's some Postgres things happening and `nginx` might be ready to do reverse proxying), so let's see what happens.

This change:
* Swaps the DNS record for `opentracker.app` to hit the secondary instance instead of the current primary
