### PR TITLE
feat: snapshot existing instance

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,6 +30,11 @@ resource "digitalocean_droplet" "main" {
   monitoring = true
 }
 
+resource "digitalocean_droplet_snapshot" "original-main-snapshot" {
+  droplet_id = digitalocean_droplet.main.id
+  name       = "original-main-snapshot"
+}
+
 resource "digitalocean_droplet" "secondary" {
   name       = "secondary"
   image      = "ubuntu-22-10-x64"


### PR DESCRIPTION
Currently being billed for the primary and the secondary, with the old Kube cluster on the primary and the secondary running `opentracker`. Just in case we need the primary again (for data recovery), we should take a snapshot before destroying it.

This change:
* Adds a `digitalocean_droplet_snapshot` resource to take a snapshot image of the existing `main` droplet
