### PR TITLE
feat: add remote state bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,6 +10,10 @@ variable "do_token" {
   type = string
 }
 
+resource "aws_s3_bucket" "remote_state" {
+  bucket = "terraform-remote-state-m3rc9k"
+}
+
 resource "digitalocean_project" "blackboards" {
   name        = "blackboards"
   purpose     = "Service or API"


### PR DESCRIPTION
Storing the state in Terraform Cloud is a little annoying since it's managed by a third-party and runs everything remotely. It would be nice to store the state in an S3 bucket and use the `s3` backend instead.

This change:
* Creates a bucket called `terraform-remote-state` with a random suffix
