### PR TITLE
feat: create Postgres instance

### DIFF
--- a/terraform/digital_ocean.tf
+++ b/terraform/digital_ocean.tf
@@ -35,6 +35,15 @@ resource "digitalocean_droplet" "secondary" {
   ssh_keys   = [23928565]
 }
 
+resource "digitalocean_droplet" "postgres" {
+  name       = "postgres"
+  image      = "ubuntu-22-10-x64"
+  region     = "lon1"
+  size       = "s-1vcpu-512mb-10gb"
+  monitoring = true
+  ssh_keys   = [digitalocean_ssh_key.m2.id]
+}
+
 resource "digitalocean_domain" "blackboards" {
   name = "blackboards.pl"
 }


### PR DESCRIPTION
The fact that the data for OpenTracker is stored on the same server as the backend and frontend is quite annoying. This makes it very difficult to replace the instance, since the data must remain intact and cannot be lost.

Ideally, we'd move the data to a separate instance and begin backing it up regularly. This would allow the stateless Docker images to be moved around much more easily as well as torn down whenever.

This change:
* Adds a new droplet of the smallest possible size to act as a Postgres server
