### PR TITLE
fix: update instance size

### DIFF
--- a/terraform/digital_ocean.tf
+++ b/terraform/digital_ocean.tf
@@ -39,7 +39,7 @@ resource "digitalocean_droplet" "postgres" {
   name       = "postgres"
   image      = "ubuntu-22-10-x64"
   region     = "lon1"
-  size       = "s-1vcpu-512mb-10gb"
+  size       = "s-1vcpu-1gb"
   monitoring = true
   ssh_keys   = [digitalocean_ssh_key.m2.id]
 }


### PR DESCRIPTION
This instance size isn't available in the London region, so let's go for the next smallest one.

This change:
* Updates the instance size to the same one as being currently used
