### PR TITLE
feat: create IAM user for backups

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -102,3 +102,33 @@ resource "aws_iam_user_login_profile" "personal" {
   user    = aws_iam_user.personal.name
   pgp_key = file("keys/pgp-b64.key")
 }
+
+resource "aws_iam_user" "postgres_backups" {
+  name = "postgres.backups"
+}
+
+resource "aws_iam_access_key" "postgres_backups" {
+  user    = aws_iam_user.postgres_backups.name
+  pgp_key = file("keys/pgp-b64.key")
+}
+
+resource "aws_iam_user_policy" "postgres_backups" {
+  name = format("%s.policy", aws_iam_user.postgres_backups.name)
+  user = aws_iam_user.postgres_backups.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["s3:ListBucket"]
+        Effect   = "Allow"
+        Resource = aws_s3_bucket.postgres_backups.arn
+      },
+      {
+        Action   = ["s3:PutObject"]
+        Effect   = "Allow"
+        Resource = format("%s/*", aws_s3_bucket.postgres_backups.arn)
+      },
+    ]
+  })
+}


### PR DESCRIPTION
In order to upload to the S3 bucket, we'll want a separate user with minimal permissions to login and perform the transfer. In this case, let's create a new `postgres.backups` user with permissions to list the bucket (for sanity) and to put objects in the bucket.

This change:
* Adds a new IAM user with an access key
* Adds a policy allowing some permissions on the backup bucket
