### PR TITLE
refactor: add S3 bucket module

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,25 +1,11 @@
-resource "aws_s3_bucket" "remote_state" {
-  bucket = "terraform-remote-state-m3rc9k"
+module "remote_state" {
+  source      = "./modules/s3-bucket"
+  bucket_name = "terraform-remote-state-m3rc9k"
 }
 
-resource "aws_s3_bucket_versioning" "remote_state" {
-  bucket = aws_s3_bucket.remote_state.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket" "postgres_backups" {
-  bucket = "postgres-backups-tr1pjq"
-}
-
-resource "aws_s3_bucket_versioning" "postgres_backups" {
-  bucket = aws_s3_bucket.postgres_backups.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
+module "postgres_backups" {
+  source      = "./modules/s3-bucket"
+  bucket_name = "postgres-backups-tr1pjq"
 }
 
 resource "aws_iam_role" "iac_deployer" {
@@ -122,12 +108,12 @@ resource "aws_iam_user_policy" "postgres_backups" {
       {
         Action   = ["s3:ListBucket"]
         Effect   = "Allow"
-        Resource = aws_s3_bucket.postgres_backups.arn
+        Resource = module.postgres_backups.arn
       },
       {
         Action   = ["s3:PutObject"]
         Effect   = "Allow"
-        Resource = format("%s/*", aws_s3_bucket.postgres_backups.arn)
+        Resource = format("%s/*", module.postgres_backups.arn)
       },
     ]
   })

--- a/terraform/modules/s3-bucket/main.tf
+++ b/terraform/modules/s3-bucket/main.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/terraform/modules/s3-bucket/outputs.tf
+++ b/terraform/modules/s3-bucket/outputs.tf
@@ -1,0 +1,3 @@
+output "arn" {
+  value = aws_s3_bucket.this.arn
+}

--- a/terraform/modules/s3-bucket/variables.tf
+++ b/terraform/modules/s3-bucket/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  type        = string
+  description = "The name of the bucket to create"
+}


### PR DESCRIPTION
Both S3 buckets currently need to be created with versioning enabled, so let's remove some of the duplication and begin defining a module.

Note: this state has been moved manually already, so there shouldn't be anything in the plan.

This change:
* Adds a new `s3-bucket` module
* Uses it for the Postgres backups and remote state
