### PR TITLE
feat: add more permissions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -41,7 +41,17 @@ resource "aws_iam_policy" "iac_deployer" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action   = ["s3:ListBucket", "s3:Get*"]
+        Action = [
+          "s3:ListBucket",
+          "s3:Get*",
+          "iam:GetUser",
+          "iam:GetUserPolicy",
+          "iam:GetPolicy",
+          "iam:GetRole",
+          "iam:GetPolicyVersion",
+          "iam:ListAccessKeys",
+          "iam:GetLoginProfile"
+        ]
         Effect   = "Allow"
         Resource = "*"
       }


### PR DESCRIPTION
In order to swap to using the S3 bucket for managing state (and using the IACDeployer role), it needs more permissions to even begin to reconcile the state.

This change:
* Adds some more neccessary permissions from local testing
