### PR TITLE
fix: remove permadiff

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -315,7 +315,7 @@ resource "aws_instance" "primary" {
   key_name      = aws_key_pair.main.key_name
   subnet_id     = aws_subnet.main.id
 
-  security_groups = [
+  vpc_security_group_ids = [
     aws_security_group.ssh.id,
     aws_security_group.http.id,
     aws_security_group.https.id


### PR DESCRIPTION
Currently, Terraform always reports that the EC2 instance has changed and thus needs to be recreated. This is fine while it's not doing anything but would be a pain if it was actually serving any traffic.

Turns out this is due to the use of `security_groups` despite the instance being in a non-default VPC, so we need to correct that.

This change:
* Updates the parameter name
