### PR TITLE
fix: correct name definition

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -440,7 +440,7 @@ resource "aws_route53_zone" "opentracker" {
 
 resource "aws_route53_record" "opentracker" {
   zone_id = aws_route53_zone.opentracker.id
-  name    = "@"
+  name    = ""
   type    = "A"
   ttl     = 300
   records = ["157.245.46.69"]


### PR DESCRIPTION
Using `@` here creates a literal record with `@` as the base, so apparently this can just be an empty string which produces the right result.

This change:
* Updates the name
