### PR TITLE
feat: point root to new instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -443,13 +443,5 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = ["157.245.46.69"]
-}
-
-resource "aws_route53_record" "opentracker-testing" {
-  zone_id = aws_route53_zone.opentracker.id
-  name    = "testing"
-  type    = "A"
-  ttl     = 300
   records = [aws_eip.primary.public_ip]
 }


### PR DESCRIPTION
Certificates have been moved to the new instance and `f2` has been restarted, so we can move traffic over to it.

This change:
* Removes the testing record, since it won't work anymore
* Updates the root record to go to the instance
