### PR TITLE
feat: add module for `f2`

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -418,6 +418,19 @@ resource "aws_eip" "primary" {
   depends_on = [aws_internet_gateway.main]
 }
 
+module "f2_instance" {
+  source = "./modules/f2-instance"
+
+  name          = "main"
+  tag           = "20230826-1932"
+  config_arn    = module.configuration_bucket.arn
+  vpc_id        = aws_vpc.main.id
+  subnet_id     = aws_subnet.main.id
+  ami           = "ami-0ab14756db2442499"
+  instance_type = "t2.nano"
+  key_name      = aws_key_pair.main.key_name
+}
+
 # Route table definitions
 resource "aws_route_table" "gateway" {
   vpc_id = aws_vpc.main.id
@@ -444,4 +457,12 @@ resource "aws_route53_record" "opentracker" {
   type    = "A"
   ttl     = 300
   records = [aws_eip.primary.public_ip]
+}
+
+resource "aws_route53_record" "opentracker-testing" {
+  zone_id = aws_route53_zone.opentracker.id
+  name    = "testing"
+  type    = "A"
+  ttl     = 300
+  records = [module.f2_instance.public_ip]
 }

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -1,0 +1,186 @@
+# IAM policies and roles
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = format("%s-role", var.name)
+  description        = format("Role for the %s instance", var.name)
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+resource "aws_iam_policy" "this" {
+  name        = format("%s-policy", var.name)
+  description = format("Policy for %s-role", var.name)
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["s3:ListBucket"]
+        Effect   = "Allow"
+        Resource = var.config_arn
+      },
+      {
+        Action   = ["s3:GetObject"]
+        Effect   = "Allow"
+        Resource = format("%s/*", var.config_arn)
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.this.arn
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = format("%s-instance-profile", var.name)
+  role = aws_iam_role.this.name
+}
+
+# Security groups
+resource "aws_security_group" "inbound_ssh" {
+  name        = format("%s-inbound-ssh", var.name)
+  description = "Allow inbound SSH traffic"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "allow_inbound_ssh" {
+  description       = "Allow inbound SSH from anywhere"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.inbound_ssh.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_ephemeral_ssh_return" {
+  description       = "Allow ephemeral SSH traffic return"
+  type              = "egress"
+  from_port         = 1024
+  to_port           = 65535
+  protocol          = "tcp"
+  security_group_id = aws_security_group.inbound_ssh.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "inbound_https" {
+  name        = format("%s-inbound-https", var.name)
+  description = "Allow inbound HTTPS traffic"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "allow_inbound_https" {
+  description       = "Allow inbound HTTPS from anywhere"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.inbound_https.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_ephemeral_https_return" {
+  description       = "Allow ephemeral HTTPS traffic return"
+  type              = "egress"
+  from_port         = 1024
+  to_port           = 65535
+  protocol          = "tcp"
+  security_group_id = aws_security_group.inbound_https.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "outbound_http" {
+  name        = format("%s-outbound-http", var.name)
+  description = "Allow outbound HTTP traffic"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "allow_outbound_http" {
+  description       = "Allow outbound HTTP to anywhere"
+  type              = "egress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  security_group_id = aws_security_group.outbound_http.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_ephemeral_outbound_http_return" {
+  description       = "Allow ephemeral outbound HTTP traffic return"
+  type              = "ingress"
+  from_port         = 1024
+  to_port           = 65535
+  protocol          = "tcp"
+  security_group_id = aws_security_group.outbound_http.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "outbound_https" {
+  name        = format("%s-outbound-https", var.name)
+  description = "Allow outbound HTTPS traffic"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "allow_outbound_https" {
+  description       = "Allow outbound HTTPS to anywhere"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.outbound_https.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_ephemeral_outbound_https_return" {
+  description       = "Allow ephemeral outbound HTTPS traffic return"
+  type              = "ingress"
+  from_port         = 1024
+  to_port           = 65535
+  protocol          = "tcp"
+  security_group_id = aws_security_group.outbound_https.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_instance" "this" {
+  ami           = var.ami
+  instance_type = var.instance_type
+  key_name      = var.key_name
+  subnet_id     = var.subnet_id
+
+  user_data = templatefile("${path.module}/scripts/setup.sh", {
+    tag = var.tag
+  })
+
+  vpc_security_group_ids = [
+    aws_security_group.inbound_ssh.id,
+    aws_security_group.inbound_https.id,
+    aws_security_group.outbound_http.id,
+    aws_security_group.outbound_https.id
+  ]
+
+  iam_instance_profile = aws_iam_instance_profile.this.name
+
+  metadata_options {
+    # Since we'll be running containers, we need an extra hop
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 2
+  }
+
+  user_data_replace_on_change = true
+}
+
+resource "aws_eip" "this" {
+  instance = aws_instance.this.id
+  domain   = "vpc"
+}

--- a/terraform/modules/f2-instance/outputs.tf
+++ b/terraform/modules/f2-instance/outputs.tf
@@ -1,0 +1,3 @@
+output "public_ip" {
+  value = aws_eip.this.public_ip
+}

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Update existing list of packages and install some basic ones
+sudo apt update
+sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
+
+# Set up the Docker registry
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Update the package list and install Docker
+sudo apt update
+sudo apt install -y docker-ce
+
+# Allow the `ubuntu` user to run `docker` commands (for SSH access)
+sudo usermod -aG docker ubuntu
+
+sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -p 443:443 alexanderjackson/f2:${tag} -- --config s3://configuration-sfvz2s/f2/config.yaml

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -1,0 +1,39 @@
+variable "name" {
+  type        = string
+  description = "Unique name of the instance"
+}
+
+variable "tag" {
+  type        = string
+  description = "The tag of the Docker image to run for `f2`"
+}
+
+variable "config_arn" {
+  type        = string
+  description = "The ARN of the configuration bucket"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The identifier of the VPC for the security groups"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "The identifier of the subnet to place the instance in"
+}
+
+variable "ami" {
+  type        = string
+  description = "The ami to use for the instance"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "The class/type to use for the instance"
+}
+
+variable "key_name" {
+  type        = string
+  description = "The name of the `aws_key_pair` to use for the instance access"
+}


### PR DESCRIPTION
Terraform is designed to be composable, but the current set of definitions is just a big ball of spaghetti. There's an `s3-bucket` module which is useful, but it would also be good to have a module for creating instances running `f2` for the purposes of upgrades.

Additionally, there's some user setup required at the moment to install Docker, update all the packages and then run the `f2` container. This can all be automated instead.

This change:
* Adds a module to create IAM roles, security groups and an EC2 instance running a specific version of the `f2` container
* Creates a new instance using the module, with the expectation of failing it over to be the primary
