### PR TITLE
feat: swap traffic to module

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -456,7 +456,7 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [aws_eip.primary.public_ip]
+  records = [module.f2_instance.public_ip]
 }
 
 resource "aws_route53_record" "opentracker-testing" {
@@ -464,5 +464,5 @@ resource "aws_route53_record" "opentracker-testing" {
   name    = "testing"
   type    = "A"
   ttl     = 300
-  records = [module.f2_instance.public_ip]
+  records = [aws_eip.primary.public_ip]
 }


### PR DESCRIPTION
The `f2` instance is up and running now with the containers, so let's swap traffic to it.

This change:
* Moves `opentracker.app` traffic to the new instance
* Moves `testing.opentracker.app` traffic to the old one
