### PR TITLE
feat: add Postgres record

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -245,3 +245,23 @@ resource "aws_route53_record" "postgres" {
   ttl     = 300
   records = [module.postgres.public_ip]
 }
+
+resource "aws_route53_zone" "internal" {
+  name = "opentracker.internal"
+
+  vpc {
+    vpc_id = aws_vpc.main.id
+  }
+
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+}
+
+resource "aws_route53_record" "internal_postgres" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "postgres"
+  type    = "CNAME"
+  ttl     = 300
+  records = [module.postgres.private_dns]
+}

--- a/terraform/modules/postgres/outputs.tf
+++ b/terraform/modules/postgres/outputs.tf
@@ -5,3 +5,7 @@ output "public_ip" {
 output "security_group_id" {
   value = aws_security_group.this.id
 }
+
+output "private_dns" {
+  value = aws_instance.this.private_dns
+}


### PR DESCRIPTION
Since the Postgres instance could change IP address over time, we probably want a nicer way of referring to it.

This change:
* Creates an internal zone for the VPC
* Creates a CNAME record to the instance
