### PR TITLE
feat: update `tag-updater`

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -42,7 +42,7 @@ services:
 
   tag-updater:
     image: alexanderjackson/tag-updater
-    tag: 20230919-1925
+    tag: 20230920-0525
     port: 4025
     replicas: 1
     host: opentracker.app


### PR DESCRIPTION
This contains some CA certificate fixes, which might allow it to start.

This change:
* Bumps the tag version
