### PR TITLE
feat: allow outbound SSH traffic

### DIFF
--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -74,6 +74,16 @@ resource "aws_security_group_rule" "allow_inbound_https" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "allow_outbound_ssh" {
+  description       = "Allow outbound SSH to anywhere"
+  type              = "egress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.this.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group_rule" "allow_outbound_http" {
   description       = "Allow outbound HTTP to anywhere"
   type              = "egress"


### PR DESCRIPTION
`tag-updater` pulls down the `infrastructure` repository using SSH, but this is currently failing as the network doesn't allow this.

This change:
* Adds an egress rule to allow SSH traffic
