### PR TITLE
feat: update `tag-updater`

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -42,7 +42,7 @@ services:
 
   tag-updater:
     image: alexanderjackson/tag-updater
-    tag: 20230920-0525
+    tag: 20230920-0608
     port: 4025
     replicas: 1
     host: opentracker.app


### PR DESCRIPTION
This contains a fix for the SSH handling that should allow it to start up and begin serving requests.

This change:
* Bumps the tag version
