### PR TITLE
refactor: allow specifying config location

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -223,6 +223,8 @@ module "f2_instance" {
   ami           = "ami-0ab14756db2442499"
   instance_type = "t2.nano"
   key_name      = aws_key_pair.main.key_name
+  config_bucket = module.configuration_bucket.name
+  config_key    = "f2/config.yaml"
 }
 
 # Route table definitions

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -135,7 +135,9 @@ resource "aws_instance" "this" {
   subnet_id     = var.subnet_id
 
   user_data = templatefile("${path.module}/scripts/setup.sh", {
-    tag = var.tag
+    tag           = var.tag
+    config_bucket = var.config_bucket
+    config_key    = var.config_key
   })
 
   vpc_security_group_ids = [aws_security_group.this.id]

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -15,4 +15,4 @@ sudo apt install -y docker-ce
 # Allow the `ubuntu` user to run `docker` commands (for SSH access)
 sudo usermod -aG docker ubuntu
 
-sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -p 443:443 alexanderjackson/f2:${tag} -- --config s3://configuration-sfvz2s/f2/config.yaml
+sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -p 443:443 alexanderjackson/f2:${tag} -- --config s3://${config_bucket}/${config_key}

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -37,3 +37,13 @@ variable "key_name" {
   type        = string
   description = "The name of the `aws_key_pair` to use for the instance access"
 }
+
+variable "config_bucket" {
+  type        = string
+  description = "The name of the bucket to use for configuration"
+}
+
+variable "config_key" {
+  type        = string
+  description = "The key in the bucket to use for configuration"
+}


### PR DESCRIPTION
Some of the S3 buckets will need recreating as part of a refactor, as they use hardcoded identifiers instead of the `random_id` resource native to Terraform. As part of this, a new configuration bucket will be created, everything copied over and a new `f2-instance` spun up.

Specifying the configuration location is also useful for running a demo/prod setup in the future or for doing failovers of `f2` itself.

Note: this is a no-op, the configuration comes out the same.

This change:
* Adds variables to the `f2-instance` module and passes them into the script
* Updates the instance definition
