### PR TITLE
feat: create new config bucket

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -47,3 +47,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f5da95bbd44809534c6678e9b1ae0b390331a5619f2ae353c6b88e96ae855cc0",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -13,6 +13,12 @@ module "configuration_bucket" {
   bucket_name = "configuration-sfvz2s"
 }
 
+module "config_bucket" {
+  source         = "./modules/s3-bucket"
+  bucket_name    = "configuration"
+  with_random_id = true
+}
+
 resource "aws_iam_role" "iac_deployer" {
   name = "iac-deployer"
 

--- a/terraform/modules/s3-bucket/main.tf
+++ b/terraform/modules/s3-bucket/main.tf
@@ -1,5 +1,11 @@
+resource "random_id" "this" {
+  count = var.with_random_id ? 1 : 0
+
+  byte_length = 3
+}
+
 resource "aws_s3_bucket" "this" {
-  bucket = var.bucket_name
+  bucket = var.with_random_id ? format("%s-%s", var.bucket_name, random_id.this[0].hex) : var.bucket_name
 }
 
 resource "aws_s3_bucket_versioning" "this" {

--- a/terraform/modules/s3-bucket/variables.tf
+++ b/terraform/modules/s3-bucket/variables.tf
@@ -2,3 +2,9 @@ variable "bucket_name" {
   type        = string
   description = "The name of the bucket to create"
 }
+
+variable "with_random_id" {
+  type        = bool
+  description = "Whether to use a `random_id` resource"
+  default     = false
+}


### PR DESCRIPTION
The current buckets use hardcoded identifiers instead of `random_id`, so we should recreate them using this.

This change:
* Allows the `s3-bucket` module to decide the `random_id`
* Creates a new configuration bucket
