### PR TITLE
feat: create secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -236,7 +236,7 @@ module "f2_instance" {
 module "f2_instance_new" {
   source = "./modules/f2-instance"
 
-  name          = "main"
+  name          = "f2"
   tag           = "20230826-1932"
   config_arn    = module.config_bucket.arn
   vpc_id        = aws_vpc.main.id

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -233,6 +233,21 @@ module "f2_instance" {
   config_key    = "f2/config.yaml"
 }
 
+module "f2_instance_new" {
+  source = "./modules/f2-instance"
+
+  name          = "main"
+  tag           = "20230826-1932"
+  config_arn    = module.config_bucket.arn
+  vpc_id        = aws_vpc.main.id
+  subnet_id     = aws_subnet.main.id
+  ami           = "ami-0ab14756db2442499"
+  instance_type = "t2.nano"
+  key_name      = aws_key_pair.main.key_name
+  config_bucket = module.config_bucket.name
+  config_key    = "f2/config.yaml"
+}
+
 # Route table definitions
 resource "aws_route_table" "gateway" {
   vpc_id = aws_vpc.main.id


### PR DESCRIPTION
The new configuration bucket has manually been populated with the same files as the old one, so let's bring up an `f2` instance running against the new one.

This change:
* Creates a new instance of the module
