### PR TITLE
fix: correct bucket output

### DIFF
--- a/terraform/modules/s3-bucket/main.tf
+++ b/terraform/modules/s3-bucket/main.tf
@@ -1,3 +1,7 @@
+locals {
+  bucket_name = var.with_random_id ? format("%s-%s", var.bucket_name, random_id.this[0].hex) : var.bucket_name
+}
+
 resource "random_id" "this" {
   count = var.with_random_id ? 1 : 0
 
@@ -5,7 +9,7 @@ resource "random_id" "this" {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket = var.with_random_id ? format("%s-%s", var.bucket_name, random_id.this[0].hex) : var.bucket_name
+  bucket = local.bucket_name
 }
 
 resource "aws_s3_bucket_versioning" "this" {

--- a/terraform/modules/s3-bucket/outputs.tf
+++ b/terraform/modules/s3-bucket/outputs.tf
@@ -3,5 +3,5 @@ output "arn" {
 }
 
 output "name" {
-  value = var.bucket_name
+  value = local.bucket_name
 }


### PR DESCRIPTION
The `bucket_name` variable is not necessarily the name of the bucket anymore, since it will have a random suffix.

This change:
* Updates the outputs to be correct
