### PR TITLE
feat: add additional deployer permissions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -186,12 +186,15 @@ resource "aws_iam_user_policy" "configuration_deployer" {
       {
         Action   = ["s3:ListBucket"]
         Effect   = "Allow"
-        Resource = module.configuration_bucket.arn
+        Resource = [module.configuration_bucket.arn, module.config_bucket.arn]
       },
       {
-        Action   = ["s3:PutObject"]
-        Effect   = "Allow"
-        Resource = format("%s/f2/config.yaml", module.configuration_bucket.arn)
+        Action = ["s3:PutObject"]
+        Effect = "Allow"
+        Resource = [
+          format("%s/f2/config.yaml", module.configuration_bucket.arn),
+          format("%s/f2/config.yaml", module.config_bucket.arn)
+        ]
       },
     ]
   })


### PR DESCRIPTION
The new `f2` instance is up and healthy using the other configuration bucket, so we need to give permissions for the deployer to write to it.

This change:
* Updates the IAM role policy
