### PR TITLE
feat: update config bucket

### DIFF
--- a/.github/workflows/deploy-config.yaml
+++ b/.github/workflows/deploy-config.yaml
@@ -20,7 +20,7 @@ jobs:
           aws_access_key_id: ${{ secrets.CONFIG_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.CONFIG_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           source: ./f2/config.yaml
-          dest: s3://configuration-sfvz2s/f2/config.yaml
+          dest: s3://configuration-68f6c7/f2/config.yaml
           aws_region: eu-west-1
 
       - name: Force Reconciliation

--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -5,17 +5,17 @@ alb:
   tls:
     cert_file:
       location: s3
-      bucket: configuration-sfvz2s
+      bucket: configuration-68f6c7
       key: f2/fullchain.pem
     key_file:
       location: s3
-      bucket: configuration-sfvz2s
+      bucket: configuration-68f6c7
       key: f2/privkey.pem
 
 secrets:
   private_key:
     location: s3
-    bucket: configuration-sfvz2s
+    bucket: configuration-68f6c7
     key: f2/private.key
 
 services:
@@ -49,4 +49,4 @@ services:
     path_prefix: /update-tag
     environment:
       PASSPHRASE: secret:mgVl9nw3UsAI7Kw5U7g0iAmba9YeW3Ly9i+FvJpR9EFbnfzo1EOXGBqPBVo8qhPtHjb6iW1zOqOba4y+cFj7luoRy7JQZHAu8OeJEJyRadJJQgZH3TKJtLWjM5YOtwTOmPhv9NF3FAnAqaSAelsBAu4HLVg7iR9CavLfcGUcu4t9eQtmVcaQC1jgJpJP6luy3z0NOkkoG+SCzGBIwYQGqAsGvhYqi9A49GgErUdzZjaAIb8VK8hQMOPXxQ2k7pPfe/VipkTmd2vGkdVhrU6PGBkYIwxBh6IbxajRgyau7hi7vekau/xE30VoklP/t9GpmMBJSOA6mKgFly/G8vxw7g==
-      GIT_CLONE_PRIVATE_KEY: s3://configuration-sfvz2s/tag-updater/id_rsa
+      GIT_CLONE_PRIVATE_KEY: s3://configuration-68f6c7/tag-updater/id_rsa


### PR DESCRIPTION
The configuration bucket has been swapped over and the deployer now has permissions to write to it, so we can migrate to the new one.

This change:
* Updates the `config.yaml` to refer to the new location
* Updates the deploy script to copy to the right one
