### PR TITLE
feat: flip traffic to new instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -276,7 +276,7 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [module.f2_instance.public_ip]
+  records = [module.f2_instance_new.public_ip]
 }
 
 resource "aws_route53_zone" "internal" {


### PR DESCRIPTION
The new instance is alive and well by the looks of it, so we can migrate the traffic over. This is now reading from the new configuration bucket.

This change:
* Updates the DNS record
