### PR TITLE
fix: add temporary permissions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -8,6 +8,11 @@ module "postgres_backups" {
   bucket_name = "postgres-backups-tr1pjq"
 }
 
+module "configuration_bucket" {
+  source      = "./modules/s3-bucket"
+  bucket_name = "configuration-sfvz2s"
+}
+
 module "config_bucket" {
   source         = "./modules/s3-bucket"
   bucket_name    = "configuration"
@@ -89,7 +94,7 @@ resource "aws_iam_user_policy" "personal" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action   = ["s3:ListAllMyBuckets", "s3:ListBucket", "s3:Get*", "iam:ChangePassword"]
+        Action   = ["s3:ListAllMyBuckets", "s3:ListBucket", "s3:Get*", "iam:ChangePassword", "s3:DeleteObject"]
         Effect   = "Allow"
         Resource = "*"
       },
@@ -181,12 +186,15 @@ resource "aws_iam_user_policy" "configuration_deployer" {
       {
         Action   = ["s3:ListBucket"]
         Effect   = "Allow"
-        Resource = module.config_bucket.arn
+        Resource = [module.configuration_bucket.arn, module.config_bucket.arn]
       },
       {
-        Action   = ["s3:PutObject"]
-        Effect   = "Allow"
-        Resource = format("%s/f2/config.yaml", module.config_bucket.arn)
+        Action = ["s3:PutObject"]
+        Effect = "Allow"
+        Resource = [
+          format("%s/f2/config.yaml", module.configuration_bucket.arn),
+          format("%s/f2/config.yaml", module.config_bucket.arn)
+        ]
       },
     ]
   })


### PR DESCRIPTION
Turns out you can't delete non-empty buckets, so the apply of #111 failed when deleting the bucket.

This change:
* Re-adds the bucket into configuration
* Adds temporary delete permissions to my user to clean it out
