### PR TITLE
feat: expire versioned objects

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -8,6 +8,12 @@ module "postgres_backups" {
   bucket_name = "postgres-backups-tr1pjq"
 }
 
+module "configuration_bucket" {
+  source           = "./modules/s3-bucket"
+  bucket_name      = "configuration-sfvz2s"
+  pending_deletion = true
+}
+
 module "config_bucket" {
   source         = "./modules/s3-bucket"
   bucket_name    = "configuration"

--- a/terraform/modules/s3-bucket/main.tf
+++ b/terraform/modules/s3-bucket/main.tf
@@ -19,3 +19,27 @@ resource "aws_s3_bucket_versioning" "this" {
     status = "Enabled"
   }
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  count = var.pending_deletion ? 1 : 0
+
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "delete-files"
+    status = "Enabled"
+
+    expiration {
+      days = 1
+    }
+  }
+
+  rule {
+    id     = "delete-versioned-files"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+}

--- a/terraform/modules/s3-bucket/variables.tf
+++ b/terraform/modules/s3-bucket/variables.tf
@@ -8,3 +8,9 @@ variable "with_random_id" {
   description = "Whether to use a `random_id` resource"
   default     = false
 }
+
+variable "pending_deletion" {
+  type        = bool
+  description = "Whether the bucket is pending deletion and objects should be cleared out"
+  default     = false
+}


### PR DESCRIPTION
Deleting S3 buckets is a bit of a hassle, since the ones defined by the module are versioned. To get AWS to clean them up, we can add a lifecycle configuration to delete them after a day.

This change:
* Adds back the bucket definition
* Adds the ability to mark a bucket for deletion
