### PR TITLE
refactor: rename `f2` instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -219,7 +219,7 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
-module "f2_instance_new" {
+module "f2_instance" {
   source = "./modules/f2-instance"
 
   name          = "f2"
@@ -259,7 +259,7 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [module.f2_instance_new.public_ip]
+  records = [module.f2_instance.public_ip]
 }
 
 resource "aws_route53_zone" "internal" {


### PR DESCRIPTION
It was mildly off-putting that this had `_new` on the end of it. State changes have been done locally with:

```
terraform state mv module.f2_instance_new module.f2_instance
```

This change:
* Renames it
