### PR TITLE
ci: avoid planning on apply

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -25,8 +25,5 @@ jobs:
       - name: Terraform Initialisation
         run: terraform init
 
-      - name: Terraform Plan
-        run: terraform plan -no-color -input=false
-
       - name: Terraform Apply
         run: terraform apply -auto-approve -input=false


### PR DESCRIPTION
The `terraform apply` command displays the plan beforehand. Since we're not actually saving the plan, let's just go straight to the apply.

This change:
* Removes the `plan` step
