### PR TITLE
feat: destroy demo instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -269,21 +269,6 @@ module "f2_instance" {
   config_key    = "f2/config.yaml"
 }
 
-module "demo_f2_instance" {
-  source = "./modules/f2-instance"
-
-  name          = "demo"
-  tag           = "20231007-1914"
-  config_arn    = module.config_bucket.arn
-  vpc_id        = aws_vpc.main.id
-  subnet_id     = aws_subnet.main.id
-  ami           = "ami-0ab14756db2442499"
-  instance_type = "t2.nano"
-  key_name      = aws_key_pair.main.key_name
-  config_bucket = module.config_bucket.name
-  config_key    = "f2/demo/config.yaml"
-}
-
 # Route table definitions
 resource "aws_route_table" "gateway" {
   vpc_id = aws_vpc.main.id
@@ -310,20 +295,4 @@ resource "aws_route53_record" "opentracker" {
   type    = "A"
   ttl     = 300
   records = [module.f2_instance.public_ip]
-}
-
-resource "aws_route53_record" "opentracker_testing" {
-  zone_id = aws_route53_zone.opentracker.id
-  name    = "testing"
-  type    = "A"
-  ttl     = 300
-  records = [module.demo_f2_instance.public_ip]
-}
-
-resource "aws_route53_record" "opentracker_demo" {
-  zone_id = aws_route53_zone.opentracker.id
-  name    = "demo"
-  type    = "A"
-  ttl     = 300
-  records = [module.demo_f2_instance.public_ip]
 }


### PR DESCRIPTION
This has proved at least some functionality still works and can be brought up again in the future before more testing is done.

This change:
* Destroys the demo instance
* Removes the Route53 records
