### PR TITLE
feat: update TLS configuration

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -3,14 +3,16 @@ alb:
   port: 443
   reconciliation: /reconcile
   tls:
-    cert_file:
-      location: s3
-      bucket: configuration-68f6c7
-      key: f2/fullchain.pem
-    key_file:
-      location: s3
-      bucket: configuration-68f6c7
-      key: f2/privkey.pem
+    domains:
+      opentracker.app:
+        cert_file:
+          location: s3
+          bucket: configuration-68f6c7
+          key: f2/fullchain.pem
+        key_file:
+          location: s3
+          bucket: configuration-68f6c7
+          key: f2/privkey.pem
 
 secrets:
   private_key:


### PR DESCRIPTION
Newer versions of `f2` support multiple domains using SNI, so we need to upgrade to that. This will fail to reconcile on the live instance but we'll bring up another one that supports the changes.

This change:
* Adds the `domains` property with `opentracker.app` in it
