### PR TITLE
feat: bring up secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -272,7 +272,7 @@ module "f2_instance" {
 module "primary" {
   source = "./modules/f2-instance"
 
-  name          = "f2"
+  name          = "primary"
   tag           = "20231007-1914"
   config_arn    = module.config_bucket.arn
   vpc_id        = aws_vpc.main.id

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -269,6 +269,21 @@ module "f2_instance" {
   config_key    = "f2/config.yaml"
 }
 
+module "primary" {
+  source = "./modules/f2-instance"
+
+  name          = "f2"
+  tag           = "20231007-1914"
+  config_arn    = module.config_bucket.arn
+  vpc_id        = aws_vpc.main.id
+  subnet_id     = aws_subnet.main.id
+  ami           = "ami-0ab14756db2442499"
+  instance_type = "t2.nano"
+  key_name      = aws_key_pair.main.key_name
+  config_bucket = module.config_bucket.name
+  config_key    = "f2/configuration.yaml"
+}
+
 # Route table definitions
 resource "aws_route_table" "gateway" {
   vpc_id = aws_vpc.main.id


### PR DESCRIPTION
`f2` now supports multiple certificates for TLS on the same instance using SNI, so we can bring up an instance that uses it.

This change:
* Brings up a new instance
