### PR TITLE
fix: correct bucket key

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -281,7 +281,7 @@ module "primary" {
   instance_type = "t2.nano"
   key_name      = aws_key_pair.main.key_name
   config_bucket = module.config_bucket.name
-  config_key    = "f2/configuration.yaml"
+  config_key    = "f2/config.yaml"
 }
 
 # Route table definitions


### PR DESCRIPTION
The plan was to write to a separate location for easier rollbacks, but it should be fine to do it in-place.

This change:
* Corrects the bucket key for the secondary instance
