### PR TITLE
feat: failover to new instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -309,5 +309,5 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [module.f2_instance.public_ip]
+  records = [module.primary.public_ip]
 }


### PR DESCRIPTION
The new instance is up and healthy and has been confirmed to work with TLS by updating `/etc/hosts`.

This change:
* Updates the DNS record to point to it
