### PR TITLE
feat: destroy old instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -254,21 +254,6 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
-module "f2_instance" {
-  source = "./modules/f2-instance"
-
-  name          = "f2"
-  tag           = "20230826-1932"
-  config_arn    = module.config_bucket.arn
-  vpc_id        = aws_vpc.main.id
-  subnet_id     = aws_subnet.main.id
-  ami           = "ami-0ab14756db2442499"
-  instance_type = "t2.nano"
-  key_name      = aws_key_pair.main.key_name
-  config_bucket = module.config_bucket.name
-  config_key    = "f2/config.yaml"
-}
-
 module "primary" {
   source = "./modules/f2-instance"
 


### PR DESCRIPTION
This is no longer serving any traffic as we've swapped over to the one that does certificate handling through SNI.

This change:
* Removes the instance
