### PR TITLE
feat: destroy some buckets

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,9 +1,3 @@
-module "remote_state" {
-  source           = "./modules/s3-bucket"
-  bucket_name      = "terraform-remote-state-m3rc9k"
-  pending_deletion = true
-}
-
 module "remote_state_bucket" {
   source         = "./modules/s3-bucket"
   bucket_name    = "terraform-remote-state"
@@ -20,12 +14,6 @@ module "postgres_backups_bucket" {
   source         = "./modules/s3-bucket"
   bucket_name    = "postgres-backups"
   with_random_id = true
-}
-
-module "configuration_bucket" {
-  source           = "./modules/s3-bucket"
-  bucket_name      = "configuration-sfvz2s"
-  pending_deletion = true
 }
 
 module "config_bucket" {
@@ -114,21 +102,6 @@ resource "aws_iam_user_policy" "personal" {
         Resource = "*"
       },
       {
-        Action   = ["s3:ListBucket"]
-        Effect   = "Allow"
-        Resource = [module.postgres_backups.arn, module.postgres_backups_bucket.arn]
-      },
-      {
-        Action   = ["s3:GetObject"]
-        Effect   = "Allow"
-        Resource = format("%s/*", module.postgres_backups.arn)
-      },
-      {
-        Action   = ["s3:PutObject"]
-        Effect   = "Allow"
-        Resource = format("%s/*", module.postgres_backups_bucket.arn)
-      },
-      {
         Action   = "sts:AssumeRole",
         Effect   = "Allow",
         Resource = aws_iam_role.iac_deployer.arn
@@ -184,20 +157,14 @@ resource "aws_iam_user_policy" "postgres_backups" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action = ["s3:ListBucket"]
-        Effect = "Allow"
-        Resource = [
-          module.postgres_backups.arn,
-          module.postgres_backups_bucket.arn
-        ]
+        Action   = ["s3:ListBucket"]
+        Effect   = "Allow"
+        Resource = module.postgres_backups_bucket.arn
       },
       {
-        Action = ["s3:PutObject"]
-        Effect = "Allow"
-        Resource = [
-          format("%s/*", module.postgres_backups.arn),
-          format("%s/*", module.postgres_backups_bucket.arn)
-        ]
+        Action   = ["s3:PutObject"]
+        Effect   = "Allow"
+        Resource = format("%s/*", module.postgres_backups_bucket.arn)
       },
     ]
   })


### PR DESCRIPTION
The remote state and configuration legacy buckets seem to be eligible for deletion now and have been removed locally.

This change:
* Removes them from Terraform
* Removes some permissions for the backups bucket that are no longer
  needed
