### PR TITLE
feat: destroy legacy backups bucket

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -4,12 +4,6 @@ module "remote_state_bucket" {
   with_random_id = true
 }
 
-module "postgres_backups" {
-  source           = "./modules/s3-bucket"
-  bucket_name      = "postgres-backups-tr1pjq"
-  pending_deletion = true
-}
-
 module "postgres_backups_bucket" {
   source         = "./modules/s3-bucket"
   bucket_name    = "postgres-backups"


### PR DESCRIPTION
Backups are now stored in the bucket with a random identifier, so we can remove this one. Applied locally to avoid wasting commits.

This change:
* Removes the bucket definition
