### PR TITLE
refactor: remove `random_id` configuration

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,19 +1,16 @@
 module "remote_state_bucket" {
-  source         = "./modules/s3-bucket"
-  bucket_name    = "terraform-remote-state"
-  with_random_id = true
+  source      = "./modules/s3-bucket"
+  bucket_name = "terraform-remote-state"
 }
 
 module "postgres_backups_bucket" {
-  source         = "./modules/s3-bucket"
-  bucket_name    = "postgres-backups"
-  with_random_id = true
+  source      = "./modules/s3-bucket"
+  bucket_name = "postgres-backups"
 }
 
 module "config_bucket" {
-  source         = "./modules/s3-bucket"
-  bucket_name    = "configuration"
-  with_random_id = true
+  source      = "./modules/s3-bucket"
+  bucket_name = "configuration"
 }
 
 resource "aws_iam_role" "iac_deployer" {

--- a/terraform/modules/s3-bucket/main.tf
+++ b/terraform/modules/s3-bucket/main.tf
@@ -1,11 +1,9 @@
-locals {
-  bucket_name = var.with_random_id ? format("%s-%s", var.bucket_name, random_id.this[0].hex) : var.bucket_name
+resource "random_id" "this" {
+  byte_length = 3
 }
 
-resource "random_id" "this" {
-  count = var.with_random_id ? 1 : 0
-
-  byte_length = 3
+locals {
+  bucket_name = format("%s-%s", var.bucket_name, random_id.this.hex)
 }
 
 resource "aws_s3_bucket" "this" {

--- a/terraform/modules/s3-bucket/variables.tf
+++ b/terraform/modules/s3-bucket/variables.tf
@@ -3,12 +3,6 @@ variable "bucket_name" {
   description = "The name of the bucket to create"
 }
 
-variable "with_random_id" {
-  type        = bool
-  description = "Whether to use a `random_id` resource"
-  default     = false
-}
-
 variable "pending_deletion" {
   type        = bool
   description = "Whether the bucket is pending deletion and objects should be cleared out"


### PR DESCRIPTION
All buckets should now have a random identifier in the Terraform state, so there's no need to configure this anymore.

This change:
* Removes the usages
* Inlines all the configuration
