### PR TITLE
feat: add SES setup

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -254,3 +254,31 @@ resource "aws_route53_record" "opentracker" {
   ttl     = 300
   records = [module.primary.public_ip]
 }
+
+# SES definitions
+resource "aws_ses_email_identity" "noreply" {
+  email = "noreply@opentracker.app"
+}
+
+resource "aws_ses_domain_mail_from" "noreply" {
+  domain           = aws_ses_email_identity.noreply.email
+  mail_from_domain = "opentracker.app"
+}
+
+resource "aws_ses_domain_identity" "opentracker" {
+  domain = "opentracker.app"
+}
+
+resource "aws_route53_record" "opentracker_ses_verification" {
+  zone_id = aws_route53_zone.opentracker.zone_id
+  name    = "_amazonses.${aws_ses_domain_identity.opentracker.id}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [aws_ses_domain_identity.opentracker.verification_token]
+}
+
+resource "aws_ses_domain_identity_verification" "opentracker" {
+  domain = aws_ses_domain_identity.opentracker.id
+
+  depends_on = [aws_route53_record.opentracker_ses_verification]
+}


### PR DESCRIPTION
Emails for OpenTracker are currently sent via Gmail which tends to put them in the Spam folder as the email is rarely used. It also doesn't come from the domain itself, which makes it a little more suspicious.

SES should be relatively cheap (1000 emails a month for 10 cents) and should allow us to use `noreply@opentracker.app`.

This change:
* Defines some infrastructure for the SES setup
