### PR TITLE
fix: use subdomain

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -262,7 +262,7 @@ resource "aws_ses_email_identity" "noreply" {
 
 resource "aws_ses_domain_mail_from" "noreply" {
   domain           = aws_ses_email_identity.noreply.email
-  mail_from_domain = "opentracker.app"
+  mail_from_domain = "mail.opentracker.app"
 }
 
 resource "aws_ses_domain_identity" "opentracker" {


### PR DESCRIPTION
The apply for the previous change failed with:

```
setting MAIL FROM domain: InvalidParameterValue: Provided MAIL-FROM domain <opentracker.app> is not subdomain of the domain of the identity <noreply@opentracker.app>
```

This change:
* Sets it to be a subdomain of the identity (maybe)
