### PR TITLE
feat: bring up secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -227,6 +227,21 @@ module "primary" {
   config_key    = "f2/config.yaml"
 }
 
+module "secondary" {
+  source = "./modules/f2-instance"
+
+  name          = "secondary"
+  tag           = "20231018-1716"
+  config_arn    = module.config_bucket.arn
+  vpc_id        = aws_vpc.main.id
+  subnet_id     = aws_subnet.main.id
+  ami           = "ami-0ab14756db2442499"
+  instance_type = "t2.nano"
+  key_name      = aws_key_pair.main.key_name
+  config_bucket = module.config_bucket.name
+  config_key    = "f2/config.yaml"
+}
+
 # Route table definitions
 resource "aws_route_table" "gateway" {
   vpc_id = aws_vpc.main.id


### PR DESCRIPTION
There's a new version of `f2` with some changes around how we roll things, so we need to bring up a separate instance to switch to.

This change:
* Defines the new instance
