### PR TITLE
feat: add more DNS records

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -282,3 +282,19 @@ resource "aws_ses_domain_identity_verification" "opentracker" {
 
   depends_on = [aws_route53_record.opentracker_ses_verification]
 }
+
+resource "aws_route53_record" "opentracker_mail_mx" {
+  zone_id = aws_route53_zone.opentracker.id
+  name    = "mail"
+  type    = "MX"
+  ttl     = 300
+  records = ["10 feedback-smtp.eu-west-1.amazonses.com"]
+}
+
+resource "aws_route53_record" "opentracker_mail_txt" {
+  zone_id = aws_route53_zone.opentracker.id
+  name    = "mail"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:amazonses.com ~all"]
+}


### PR DESCRIPTION
The console is reporting that there's no MAIL FROM domain for `opentracker.app` which might be because we're missing some records. Anyhow, email is confusing.

This change:
* Adds some more records
