### PR TITLE
refactor: remove unneeded variable

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -217,7 +217,6 @@ module "secondary" {
 
   name          = "secondary"
   tag           = "20231018-1716"
-  config_arn    = module.config_bucket.arn
   vpc_id        = aws_vpc.main.id
   subnet_id     = aws_subnet.main.id
   ami           = "ami-0ab14756db2442499"

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -26,12 +26,12 @@ resource "aws_iam_policy" "this" {
       {
         Action   = ["s3:ListBucket"]
         Effect   = "Allow"
-        Resource = var.config_arn
+        Resource = format("arn:aws:s3:::%s", var.config_bucket)
       },
       {
         Action   = ["s3:GetObject"]
         Effect   = "Allow"
-        Resource = format("%s/*", var.config_arn)
+        Resource = format("arn:aws:s3:::%s/*", var.config_bucket)
       },
     ]
   })

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -8,11 +8,6 @@ variable "tag" {
   description = "The tag of the Docker image to run for `f2`"
 }
 
-variable "config_arn" {
-  type        = string
-  description = "The ARN of the configuration bucket"
-}
-
 variable "vpc_id" {
   type        = string
   description = "The identifier of the VPC for the security groups"


### PR DESCRIPTION
We already pass in the name of the configuration bucket, so we don't need to pass in the ARN as well since this is well-defined based on the name.

This change:
* Removes it
