### PR TITLE
feat: bring up secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -226,6 +226,20 @@ module "primary" {
   config_key    = "f2/config.yaml"
 }
 
+module "secondary" {
+  source = "./modules/f2-instance"
+
+  name          = "secondary"
+  tag           = "20231102-2034"
+  vpc_id        = aws_vpc.main.id
+  subnet_id     = aws_subnet.main.id
+  ami           = "ami-0ab14756db2442499"
+  instance_type = "t2.nano"
+  key_name      = aws_key_pair.main.key_name
+  config_bucket = module.config_bucket.name
+  config_key    = "f2/config.yaml"
+}
+
 # Route table definitions
 resource "aws_route_table" "gateway" {
   vpc_id = aws_vpc.main.id
@@ -252,4 +266,12 @@ resource "aws_route53_record" "opentracker" {
   type    = "A"
   ttl     = 300
   records = [module.primary.public_ip]
+}
+
+resource "aws_route53_record" "opentracker_testing" {
+  zone_id = aws_route53_zone.opentracker.id
+  name    = "testing"
+  type    = "A"
+  ttl     = 300
+  records = [module.secondary.public_ip]
 }


### PR DESCRIPTION
There's a new version of `f2` that contains an improvement to not decrypt configuration at startup, so let's bring up a new instance for it.

This change:
* Defines the secondary instance and a record for it
