### PR TITLE
feat: destroy old instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -212,20 +212,6 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
-module "primary" {
-  source = "./modules/f2-instance"
-
-  name          = "primary"
-  tag           = "20231102-1914"
-  vpc_id        = aws_vpc.main.id
-  subnet_id     = aws_subnet.main.id
-  ami           = "ami-0ab14756db2442499"
-  instance_type = "t2.nano"
-  key_name      = aws_key_pair.main.key_name
-  config_bucket = module.config_bucket.name
-  config_key    = "f2/config.yaml"
-}
-
 module "secondary" {
   source = "./modules/f2-instance"
 
@@ -266,12 +252,4 @@ resource "aws_route53_record" "opentracker" {
   type    = "A"
   ttl     = 300
   records = [module.secondary.public_ip]
-}
-
-resource "aws_route53_record" "opentracker_testing" {
-  zone_id = aws_route53_zone.opentracker.id
-  name    = "testing"
-  type    = "A"
-  ttl     = 300
-  records = [module.primary.public_ip]
 }


### PR DESCRIPTION
The old instance is no longer receiving any traffic, so we can tear it down.

This change:
* Destroys the Route53 record
* Destroys the instance itself
