### PR TITLE
feat: add EC2 permissions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -88,7 +88,12 @@ resource "aws_iam_user_policy" "personal" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action   = ["s3:ListAllMyBuckets", "s3:ListBucket", "s3:Get*", "iam:ChangePassword"]
+        Action = [
+          "ec2:DescribeInstances",
+          "s3:ListAllMyBuckets",
+          "s3:ListBucket",
+          "iam:ChangePassword",
+        ]
         Effect   = "Allow"
         Resource = "*"
       },


### PR DESCRIPTION
It's useful to be able to list the instances locally. This doesn't allow any changes to be made, so it's safe to have on a default user account.

This change:
* Removes `s3:Get*`
* Adds `ec2:DescribeInstances`
