### PR TITLE
feat: add Route53 permissions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -220,15 +220,16 @@ resource "aws_key_pair" "main" {
 module "secondary" {
   source = "./modules/f2-instance"
 
-  name          = "secondary"
-  tag           = "20231102-2034"
-  vpc_id        = aws_vpc.main.id
-  subnet_id     = aws_subnet.main.id
-  ami           = "ami-0ab14756db2442499"
-  instance_type = "t2.nano"
-  key_name      = aws_key_pair.main.key_name
-  config_bucket = module.config_bucket.name
-  config_key    = "f2/config.yaml"
+  name           = "secondary"
+  tag            = "20231102-2034"
+  vpc_id         = aws_vpc.main.id
+  subnet_id      = aws_subnet.main.id
+  ami            = "ami-0ab14756db2442499"
+  instance_type  = "t2.nano"
+  key_name       = aws_key_pair.main.key_name
+  config_bucket  = module.config_bucket.name
+  config_key     = "f2/config.yaml"
+  hosted_zone_id = aws_route53_zone.opentracker.id
 }
 
 # Route table definitions

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -33,6 +33,16 @@ resource "aws_iam_policy" "this" {
         Effect   = "Allow"
         Resource = format("arn:aws:s3:::%s/*", var.config_bucket)
       },
+      {
+        Action   = ["route53:ListHostedZones", "route53:GetChange"]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+      {
+        Action   = ["route53:ChangeResourceRecordSets"]
+        Effect   = "Allow"
+        Resource = format("arn:aws:route53:::hostedzone/%s", var.hosted_zone_id)
+      },
     ]
   })
 }

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -42,3 +42,8 @@ variable "config_key" {
   type        = string
   description = "The key in the bucket to use for configuration"
 }
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "The hosted zone identifier for Let's Encrypt renewals"
+}


### PR DESCRIPTION
Currently, the SSL certificates do not automatically renew which is a bit annoying. There's a Route53 extension for Certbot that will handle this using `dns-01` challenges, which might be useful to experiment with.

This change:
* Adds some Route53 permissions to the IAM role
