### PR TITLE
feat: add `tags` DNS record

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -259,3 +259,11 @@ resource "aws_route53_record" "opentracker" {
   ttl     = 300
   records = [module.secondary.public_ip]
 }
+
+resource "aws_route53_record" "opentracker_tags" {
+  zone_id = aws_route53_zone.opentracker.id
+  name    = "tags"
+  type    = "A"
+  ttl     = 300
+  records = [module.secondary.public_ip]
+}


### PR DESCRIPTION
`tag-updater` is being moved to `tags.opentracker.app` as an experimentation for adding new applications. The certificates exist and `f2` knows about it, but there's no actual DNS record yet.

This change:
* Creates one for it
