### PR TITLE
fix: rollback `tag-updater`

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -53,7 +53,7 @@ services:
 
   tag-updater:
     image: alexanderjackson/tag-updater
-    tag: 20231108-1758
+    tag: 20231108-1750
     port: 4025
     replicas: 1
     host: tags.opentracker.app


### PR DESCRIPTION
This version is failing to push changes to the remote as it is using `master` instead of `origin`.

This change:
* Reverts be5f42bda9133aaf8cf057e17295ad65332964f3
