### PR TITLE
fix: bump `stock-notifier`

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -63,7 +63,7 @@ services:
 
   stock-notifier:
     image: alexanderjackson/stock-notifier
-    tag: 20231109-1612
+    tag: 20231110-0935
     port: 4025
     replicas: 1
     host: stocks.opentracker.app


### PR DESCRIPTION
This hasn't been being updated since the repository didn't have the passphrase for `tag-updater`.

This change:
* Bumps to the latest version
