### PR TITLE
refactor: Postgres instance parameters

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -223,10 +223,10 @@ module "secondary" {
   name   = "secondary"
 
   instance = {
+    type      = "t2.nano"
     ami       = "ami-0ab14756db2442499"
     vpc_id    = aws_vpc.main.id
     subnet_id = aws_subnet.main.id
-    type      = "t2.nano"
   }
 
   configuration = {
@@ -241,20 +241,26 @@ module "secondary" {
 
 module "database" {
   source = "./modules/postgres"
+  name   = "database"
   count  = 0
 
-  name                 = "database"
-  major_version        = "15"
-  backup_bucket        = module.postgres_backups_bucket.name
-  configuration_bucket = module.config_bucket.name
-  vpc_id               = aws_vpc.main.id
-  subnet_id            = aws_subnet.main.id
-  availability_zone    = "eu-west-1a"
-  storage_size         = 1
-  ami                  = "ami-0a1b36900d715a3ad"
-  instance_type        = "t4g.nano"
-  key_name             = aws_key_pair.main.key_name
-  permitted_access     = [module.secondary.security_group_id]
+  instance = {
+    type              = "t4g.nano"
+    ami               = "ami-0a1b36900d715a3ad"
+    vpc_id            = aws_vpc.main.id
+    subnet_id         = aws_subnet.main.id
+    availability_zone = "eu-west-1a"
+  }
+
+  configuration = {
+    major_version        = "15"
+    storage_size         = 1
+    backup_bucket        = module.postgres_backups_bucket.name
+    configuration_bucket = module.config_bucket.name
+  }
+
+  key_name         = aws_key_pair.main.key_name
+  permitted_access = [module.secondary.security_group_id]
 }
 
 # Route table definitions

--- a/terraform/modules/postgres/variables.tf
+++ b/terraform/modules/postgres/variables.tf
@@ -3,49 +3,25 @@ variable "name" {
   description = "Unique name of the instance"
 }
 
-variable "major_version" {
-  type        = string
-  description = "The major version of Postgres to run on the instance"
+variable "instance" {
+  type = object({
+    type              = string
+    ami               = string
+    vpc_id            = string
+    subnet_id         = string
+    availability_zone = string
+  })
+  description = "Parameters for the underlying EC2 instance"
 }
 
-variable "backup_bucket" {
-  type        = string
-  description = "The name of the backup bucket"
-}
-
-variable "configuration_bucket" {
-  type        = string
-  description = "The name of the configuration bucket"
-}
-
-variable "vpc_id" {
-  type        = string
-  description = "The identifier of the VPC for the security groups"
-}
-
-variable "subnet_id" {
-  type        = string
-  description = "The identifier of the subnet to place the instance in"
-}
-
-variable "availability_zone" {
-  type        = string
-  description = "The availability zone for the instance and storage volume"
-}
-
-variable "storage_size" {
-  type        = number
-  description = "The amount of storage to allocate for the instance in GB"
-}
-
-variable "ami" {
-  type        = string
-  description = "The ami to use for the instance"
-}
-
-variable "instance_type" {
-  type        = string
-  description = "The class/type to use for the instance"
+variable "configuration" {
+  type = object({
+    major_version        = string
+    storage_size         = number
+    backup_bucket        = string
+    configuration_bucket = string
+  })
+  description = "Parameters for the underlying Postgres install"
 }
 
 variable "key_name" {


### PR DESCRIPTION
As was done for the `f2-instance` module, it's easier to read when the parameters are somewhat grouped by functionality.

This change:
* Does the same for the Postgres module
