### PR TITLE
feat: add automated backups

### DIFF
--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -130,6 +130,11 @@ resource "aws_instance" "this" {
     hba_file = templatefile("${path.module}/templates/pg_hba.conf", {
       subnet_cidr_block = data.aws_subnet.self.cidr_block
     })
+
+    backup_script = templatefile("${path.module}/templates/backup.sh", {
+      backup_bucket        = var.configuration.backup_bucket
+      configuration_bucket = var.configuration.configuration_bucket
+    })
   })
 
   vpc_security_group_ids = [aws_security_group.this.id]

--- a/terraform/modules/postgres/templates/backup.sh
+++ b/terraform/modules/postgres/templates/backup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+function perform_backup() {
+  database=$1
+  password=$2
+
+  echo "Performing backup for $database"
+
+  # Dump the contents of the database to disk
+  filename="$database.$current_date.sql"
+  PGPASSWORD=$password pg_dump -h localhost -p 5432 -d $database -U postgres > $filename
+
+  # Compress the contents
+  compressed=$filename.gz
+  gzip -c $filename > $compressed
+
+  # Upload the data to S3
+  s3_uri="s3://${backup_bucket}/$database/$compressed"
+  aws s3 cp $compressed $s3_uri
+
+  # Delete the temporary files
+  rm $filename $compressed
+
+  echo "Successfully dumped, compressed and uploaded (to $s3_uri) backup for '$database'"
+}
+
+# Download the Postgres password from S3
+aws s3 cp s3://${configuration_bucket}/postgres/password /root
+password=`cat /root/password`
+
+# Get the current date
+current_date=$(date +"%Y-%m-%dT%H:%M:%S")
+echo "Performing backups for $current_date"
+
+# Export the list of databases
+database_list="/tmp/databases.csv"
+sudo -u postgres psql -c "COPY (SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'template0', 'template1')) TO '$database_list' WITH CSV DELIMITER ','"
+
+# Backup each one of them sequentially
+while IFS= read -r database; do
+  perform_backup $database $password
+done < $database_list
+
+# Delete the list of databases and the password
+rm -f $database_list /root/password


### PR DESCRIPTION
For the Postgres instance, we probably want to be automatically backing up the databases periodically for disaster recovery situations. This is done on the current instance, so we'll want to Terraform in the capability to the new instance.

This change:
* Adds a backup script and installs it on the instances
