### PR TITLE
feat: switch to new instance

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -45,7 +45,7 @@ services:
     host: opentracker.app
     path_prefix: /api
     environment:
-      DATABASE_HOST: "64.227.33.121"
+      DATABASE_HOST: 10.0.0.238
       DATABASE_NAME: opentracker
       DATABASE_USER: postgres
       DATABASE_PASSWORD: secret:j9VBUWVGrsNDDGBUAwdSIdnxviUrHjBowc3ze+whOrg9nLY6a/GjVYTnWW8QYeIdGsP9X2o4Ns12+THcpZserHqvLkaBEZUFy83x238WfV7NKhMAMQonD9N/VIZX9r5ukBFK6g37dnu1UJK9ttf3MGHkZ7s36sogR9Q50J9OX5NjVKIlV4EZh5/KSTHxJLFWCk7Fuu0Bxqer7PL4s8ZGKjTFVYNMZDxhc4D7qNf3JnQHejyHc8RjJ2A/ggsMknbVUHruGejsF45aLmvhjJvpVs2XlFmeQ92e9cjY/11ORGN+L7IMoM8RH5txuJF1gp49ExPVAhidt0dX6BGnndt3Uw==


### PR DESCRIPTION
The new Postgres instance on the AWS side has come up now, so we can move the traffic over to it. This will mean there is no data, but it can be moved over from the old one shortly.

This change:
* Swaps the host for `opentracker-backend`
