### PR TITLE
feat: remove EIP for Postgres

### DIFF
--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -144,11 +144,6 @@ resource "aws_instance" "this" {
   user_data_replace_on_change = true
 }
 
-resource "aws_eip" "this" {
-  instance = aws_instance.this.id
-  domain   = "vpc"
-}
-
 # Storage definition
 resource "aws_ebs_volume" "this" {
   availability_zone = var.instance.availability_zone


### PR DESCRIPTION
Elastic IPs will cost money in the future and this was only so that we could get onto the instance for setup and debugging purposes. The instance should function fine from now, so we can remove the EIP allocation.

We can also always reassociate it if we need to SSH onto it.

This change:
* Removes the `aws_eip` resource from the Postgres instance
