### PR TITLE
feat: destroy Digital Ocean infrastructure

### DIFF
--- a/terraform/digital_ocean.tf
+++ b/terraform/digital_ocean.tf
@@ -4,26 +4,5 @@ resource "digitalocean_project" "blackboards" {
   environment = "Production"
   is_default  = true
 
-  resources = [
-    digitalocean_droplet.postgres.urn,
-  ]
-}
-
-resource "digitalocean_ssh_key" "m2" {
-  name       = "m2"
-  public_key = file("keys/id_rsa.pub")
-}
-
-resource "digitalocean_ssh_key" "secondary" {
-  name       = "secondary"
-  public_key = file("keys/secondary_id_rsa.pub")
-}
-
-resource "digitalocean_droplet" "postgres" {
-  name       = "postgres"
-  image      = "ubuntu-22-10-x64"
-  region     = "lon1"
-  size       = "s-1vcpu-1gb"
-  monitoring = true
-  ssh_keys   = [digitalocean_ssh_key.m2.id, digitalocean_ssh_key.secondary.id]
+  resources = []
 }


### PR DESCRIPTION
All the traffic has been moved over to AWS now, so there's no point maintaining this instance as well.

This change:
* Removes the droplet from the project
* Destroys the droplet itself
* Removes the remaining SSH keys
