### PR TITLE
feat: begin supporting IPV6

### DIFF
--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -84,6 +84,16 @@ resource "aws_security_group_rule" "allow_inbound_https" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "allow_inbound_ipv6_https" {
+  description       = "Allow inbound HTTPS from anywhere on IPV6"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.this.id
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
 resource "aws_security_group_rule" "allow_outbound_ssh" {
   description       = "Allow outbound SSH to anywhere"
   type              = "egress"
@@ -151,8 +161,8 @@ resource "aws_instance" "this" {
   })
 
   vpc_security_group_ids = [aws_security_group.this.id]
-
-  iam_instance_profile = aws_iam_instance_profile.this.name
+  iam_instance_profile   = aws_iam_instance_profile.this.name
+  ipv6_address_count     = var.instance.ipv6_address_count
 
   metadata_options {
     # Since we'll be running containers, we need an extra hop

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -5,10 +5,11 @@ variable "name" {
 
 variable "instance" {
   type = object({
-    ami       = string
-    vpc_id    = string
-    subnet_id = string
-    type      = string
+    ami                = string
+    vpc_id             = string
+    subnet_id          = string
+    type               = string
+    ipv6_address_count = number
   })
   description = "Parameters for the underlying EC2 instance"
 }


### PR DESCRIPTION
AWS EIPs will begin costing money in early 2024 as IPV4 addresses become more sparse. Since we host a single server (for HTTP traffic), we might be able to get away with just supporting IPV6 addresses which will be free.

This change:
* Updates the VPC and subnet to support IPV6 addressing
* Adds a V6 route to the internet gateway
* Creates a new `f2-instance` that assigns an IPV6 address
* Adds a security group rule to allow inbound HTTPS traffic on IPV6
