### PR TITLE
fix: add IPv6 subnet CIDR

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -206,6 +206,7 @@ resource "aws_vpc" "main" {
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.0.0.0/24"
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 0)
   availability_zone = "eu-west-1a"
 
   assign_ipv6_address_on_creation = true


### PR DESCRIPTION
The update of the subnet failed since it didn't have an IPv6 CIDR block to work with, so this derives it from the VPC itself using some Terraform magic.

This will also need to finish creating the `f2-instance` from the previous change as some of that relied on the subnet.

This change:
* Adds the `ipv6_cidr_block` parameter for the subnet
