### PR TITLE
feat: destroy primary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -223,29 +223,6 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
-module "primary" {
-  source = "./modules/f2-instance"
-  name   = "primary"
-
-  instance = {
-    type      = "t2.nano"
-    ami       = "ami-0ab14756db2442499"
-    vpc_id    = aws_vpc.main.id
-    subnet_id = aws_subnet.main.id
-
-    ipv6_address_count = 1
-  }
-
-  configuration = {
-    bucket    = module.config_bucket.name
-    key       = "f2/config.yaml"
-    image_tag = "20231209-1709"
-  }
-
-  key_name       = aws_key_pair.main.key_name
-  hosted_zone_id = aws_route53_zone.opentracker.id
-}
-
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "secondary"


### PR DESCRIPTION
This is currently not serving any traffic and was an experiment into IPv6 addressing. It's costing some money, so let's tear it down for the time being.

This change:
* Destroys the instance
