### PR TITLE
feat: remove Digital Ocean file

### DIFF
--- a/terraform/digital_ocean.tf
+++ b/terraform/digital_ocean.tf
@@ -1,8 +1,0 @@
-resource "digitalocean_project" "blackboards" {
-  name        = "blackboards"
-  purpose     = "Service or API"
-  environment = "Production"
-  is_default  = true
-
-  resources = []
-}


### PR DESCRIPTION
There's nothing being hosted in Digital Ocean anymore so we can empty the file. This should delete the project (if required) and then we can remove all the references.
