### PR TITLE
feat: remove Digital Ocean references

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,10 +5,9 @@ now managed by Terraform.
 
 ## Contents
 
-`aws.tf` contains the definitions for everything in AWS and `digital_ocean.tf`
-contains the remaining Digital Ocean infrastructure. The `modules` directory
-contains some custom components for definitions such as S3 buckets, `f2`
-instances and PostgreSQL databases.
+`aws.tf` contains the definitions for everything in AWS. The `modules`
+directory contains some custom components for definitions such as S3 buckets,
+`f2` instances and PostgreSQL databases.
 
 The project defines:
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,11 +1,3 @@
-provider "digitalocean" {
-  token = var.do_token
-}
-
 provider "aws" {
   region = "eu-west-1"
-}
-
-variable "do_token" {
-  type = string
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,9 +1,5 @@
 terraform {
   required_providers {
-    digitalocean = {
-      source  = "digitalocean/digitalocean"
-      version = "=2.34.1"
-    }
     aws = {
       source  = "hashicorp/aws"
       version = "=5.32.1"


### PR DESCRIPTION
Since we have now moved everything into AWS, we can remove the remaining references to Digital Ocean.

The removal of the project did cause a pipeline failure as it was the default project, but `terraform state rm digitalocean_project.blackboards` has caused Terraform to forget about it for now.

This change:
* Removes it from the README
* Removes the providers and versions
* Removes the empty `digital_ocean.tf` file
