### PR TITLE
feat: remove `stock-notifier`

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -60,14 +60,3 @@ services:
     environment:
       PASSPHRASE: secret:mgVl9nw3UsAI7Kw5U7g0iAmba9YeW3Ly9i+FvJpR9EFbnfzo1EOXGBqPBVo8qhPtHjb6iW1zOqOba4y+cFj7luoRy7JQZHAu8OeJEJyRadJJQgZH3TKJtLWjM5YOtwTOmPhv9NF3FAnAqaSAelsBAu4HLVg7iR9CavLfcGUcu4t9eQtmVcaQC1jgJpJP6luy3z0NOkkoG+SCzGBIwYQGqAsGvhYqi9A49GgErUdzZjaAIb8VK8hQMOPXxQ2k7pPfe/VipkTmd2vGkdVhrU6PGBkYIwxBh6IbxajRgyau7hi7vekau/xE30VoklP/t9GpmMBJSOA6mKgFly/G8vxw7g==
       GIT_CLONE_PRIVATE_KEY: s3://configuration-68f6c7/tag-updater/id_rsa
-
-  stock-notifier:
-    image: alexanderjackson/stock-notifier
-    tag: 20231110-1014
-    port: 4025
-    replicas: 1
-    host: stocks.opentracker.app
-    environment:
-      PRODUCTS: secret:PnbCf9QczRmbqAnzIUizfP2Sf7nFIouHiOwHEnmLcIEabjdhaN7l2YS5+u3DyDqX56W8i0x2oXK6RnYRLIhCpLDiYfpm09EzBI4TwM6z0Q3eMYDH/1yVhfNt1QYBsfe/ECrkIm3N2ivq6fuvTM0bVtryA/olgndYblmxZRoDhsnilC5QGKtYUQwPrvrz8DhZr4jwBs2FvS+K9U1fqcxYGP69an7d8ijL1LtU4RXQ4ZOnFo/NuvtTJx7kUNPDlsT5QcZhDNt4GTX6Mxt5Ak85A0QuYsAbGkLnFy4hnks6go+l9bXuprBN4BaAPvM+2JZNItchyiEipsgLhewv6Achyw==
-      DISCORD_TOKEN: secret:bfXWASQyzM8C6c6TG4CHIibsXWFHw36yDmhrJNA8ywFFrxBw0i8nIp4bVWSrVwjBU7zORhd+buVpBv1gkBfytXgQfw23DC5HM5CWhRXP04qRjhcdAjj2/9jTG2WPpEj15bWvf47H9BaeWOfI2qpJC9Yiex8bnGMB3uJtcSVF65TwuD9nMrNEQVRSYeNUZ7DPT0qJhcz8LuoprAgn6JON8vwE0hOsmwM5irm7ZXwVIoAnkKgwZfPnklfr2k/lW8aH7FRH4hLLeMM5Kawz9diWQf438TqkJ8V3KmAiofaZGoipUZG0tGsN25FtB0J9Wjz/Un8f0ubgiXLrfbo1g71H1w==
-      CHANNEL_ID: secret:XluGGnI3gxRnZqXh629wlnu2RcEokw7Iv2yjrL9QymFnfTAsVp6Eh6+4VSAUmfesaykZAit5Q+KMaElUA5N4YZHNW3FoIDhRYR7vJyIV6t/eCyMnNYAcbCSxEeTohZWnb4nlwW7wJgtP+PpVzJ0ueeIBNO3zz0gbirFrjdCTvbsdtahlXXmd6XYpeehiDJsNGliC/+aqFzTmn+KobHRcFWQIQ4icaltw7E5sSoCymzDRM+f+0vbuXze2WRH04auGcMSv4YQgyPBBJZn4Ai3Fv8UwwleTGm+Et3hFON82LvT1aUYH2+YO89f660sU9Av4Z+r2PTkZR1H2O37mjZzNww==


### PR DESCRIPTION
This doesn't need to be running anymore, so let's remove it and save some resources on the EC2 instance (not that it was using much).

Hopefully this causes `f2` to remove the running containers properly.

This change:
* Deletes the block for `stock-notifier`
