### PR TITLE
feat: add SNS topic notifications

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -309,3 +309,13 @@ resource "aws_route53_record" "opentracker_tags" {
   ttl     = 300
   records = [module.secondary.public_ip]
 }
+
+resource "aws_sns_topic" "outages" {
+  name = "outages"
+}
+
+resource "aws_sns_topic_subscription" "outages" {
+  topic_arn = aws_sns_topic.outages.arn
+  protocol  = "email"
+  endpoint  = "alexanderjackson@protonmail.com"
+}


### PR DESCRIPTION
It would be good to have some monitoring of the server (even something basic, such as "hey, the server is down"). The RustNation conference provided a good starting point for this in the AWS Lambda talk, so let's create an SNS topic we can publish to and route emails to myself for any failures.

This change:
* Adds an SNS topic
* Subscribes my email address to the topic
