### PR TITLE
fix: correct image URI

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -385,7 +385,7 @@ locals {
 
 resource "aws_lambda_function" "uptime" {
   function_name = "uptime"
-  image_uri     = format("%s/%s", aws_ecr_repository.uptime.repository_url, local.uptime_tag)
+  image_uri     = format("%s:%s", aws_ecr_repository.uptime.repository_url, local.uptime_tag)
   package_type  = "Image"
 
   role          = aws_iam_role.uptime.arn


### PR DESCRIPTION
Image URIs are meant to be `<repo>:<tag>` instead of with a `/`.

This change:
* Corrects the formatting
