### PR TITLE
feat: deploy new lambda version

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -380,7 +380,7 @@ resource "aws_iam_role" "uptime" {
 }
 
 locals {
-  uptime_tag = "20240331-1550"
+  uptime_tag = "20240331-1712"
 }
 
 resource "aws_lambda_function" "uptime" {


### PR DESCRIPTION
A new version of `uptime` has been built, so let's upgrade the version of it.

This change:
* Bumps to the new version
