### PR TITLE
feat: bump lambda function version

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -380,7 +380,7 @@ resource "aws_iam_role" "uptime" {
 }
 
 locals {
-  uptime_tag = "20240331-1855"
+  uptime_tag = "20240331-1916"
 }
 
 resource "aws_lambda_function" "uptime" {


### PR DESCRIPTION
The lambda incorrectly expects a parameter called `TARGER_URI` instead of `TARGET_URI`, which means it is failing to be invoked every time.

This change:
* Bumps it to a new version which expects the right value
