### PR TITLE
feat: bump lambda function version

### DIFF
--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role" "uptime" {
 }
 
 locals {
-  uptime_tag = "20240331-1916"
+  uptime_tag = "20240401-1455"
 }
 
 resource "aws_lambda_function" "uptime" {


### PR DESCRIPTION
The lambda is now much smaller due to stripping debug symbols in release binaries, so let's get this running in prod.

This change:
* Bumps the version of the lambda
