### PR TITLE
feat: enable Cost Explorer for users

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -90,6 +90,8 @@ resource "aws_iam_user_policy" "personal" {
       {
         Action = [
           "autoscaling:DescribeAutoScalingGroups",
+          "ce:GetCostAndUsage",
+          "ce:GetCostForecast",
           "cloudwatch:DescribeAlarms",
           "cloudwatch:GetMetricData",
           "cloudwatch:GetMetricStatistics",


### PR DESCRIPTION
Regular user accounts should be able to view the costs associated with running the infrastructure instead of going through the root account. This requires a setting to be enabled manually in the console (unfortunately) alongside some additional permissions.

This change:
* Adds additional permissions to user accounts
