### PR TITLE
feat: remove unneeded permissions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -143,11 +143,6 @@ resource "aws_iam_user_policy" "personal" {
         ]
         Effect   = "Allow"
         Resource = "*"
-      },
-      {
-        Action   = "sts:AssumeRole",
-        Effect   = "Allow",
-        Resource = aws_iam_role.iac_deployer.arn
       }
     ]
   })


### PR DESCRIPTION
Regular users don't need the ability to assume `IACDeployer` and probably shouldn't be able to anyway.

This change:
* Removes the permission usage
