### PR TITLE
rwfactor: create `user` module

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,30 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/digitalocean/digitalocean" {
-  version     = "2.34.1"
-  constraints = "2.34.1"
-  hashes = [
-    "h1:5tfXRq80lhTUCYxAqcUGL8BjR3SSTk+ggiW20UvK+JA=",
-    "zh:022d4c97af3d022d4e3735a81c6a7297aa43c3b28a8cecaa0ff58273a5677e2e",
-    "zh:1922f86d5710707eb497fbebcb1a1c5584c843a7e95c3900d750d81bd2785204",
-    "zh:1b7ab7c67a26c399eb5aa8a7a695cb59279c6a1a562ead3064e4a6b17cdacabe",
-    "zh:1dc666faa2ec0efc32329b4c8ff79813b54741ef1741bc42d90513e5ba904048",
-    "zh:220dec61ffd9448a91cca92f2bc6642df10db57b25d3d27036c3a370e9870cb7",
-    "zh:262301545057e654bd6193dc04b01666531fccfcf722f730827695098d93afa7",
-    "zh:63677684a14e6b7790833982d203fb2f84b105ad6b9b490b3a4ecc7043cdba81",
-    "zh:67a2932227623073aa9431a12916b52ce1ccddb96f9a2d6cdae2aaf7558ccbf8",
-    "zh:70dfc6ac33ee140dcb29a971df7eeb15117741b5a75b9f8486c5468c9dd28f24",
-    "zh:7e3b3b62754e86442048b4b1284e10807e3e58f417e1d59a4575dd29ac6ba518",
-    "zh:7e6fe662b1e283ad498eb2549d0c2260b908ab5b848e05f84fa4acdca5b4d5ca",
-    "zh:9c554170f20e659222896533a3a91954fb1d210eea60de05aea803b36d5ccd5d",
-    "zh:ad2f64d758bd718eb39171f1c31219900fd2bfb552a14f6a90b18cfd178a74b4",
-    "zh:cfce070000e95dfe56a901340ac256f9d2f84a73bf62391cba8a8e9bf1f857e0",
-    "zh:d5ae30eccd53ca7314157e62d8ec53151697ed124e43b24b2d16c565054730c6",
-    "zh:fbe5edf5337adb7360f9ffef57d02b397555b6a89bba68d1b60edfec6e23f02c",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.32.1"
   constraints = "5.32.1"

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -26,14 +26,7 @@ resource "aws_iam_role" "iac_deployer" {
         Principal = {
           Service = "s3.amazonaws.com"
         }
-      },
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          AWS = aws_iam_user.personal.arn
-        }
-      },
+      }
     ]
   })
 }
@@ -71,81 +64,11 @@ resource "aws_iam_role_policy_attachment" "iac_deployer" {
   policy_arn = aws_iam_policy.iac_deployer.arn
 }
 
-resource "aws_iam_user" "personal" {
+module "personal" {
+  source = "./modules/user"
+
   name = "alex.jackson"
-}
-
-resource "aws_iam_access_key" "personal" {
-  user    = aws_iam_user.personal.name
-  pgp_key = file("keys/pgp-b64.key")
-}
-
-resource "aws_iam_user_policy" "personal" {
-  name = format("%s.policy", aws_iam_user.personal.name)
-  user = aws_iam_user.personal.name
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "autoscaling:DescribeAutoScalingGroups",
-          "ce:GetCostAndUsage",
-          "ce:GetCostForecast",
-          "cloudwatch:DescribeAlarms",
-          "cloudwatch:GetMetricData",
-          "cloudwatch:GetMetricStatistics",
-          "cloudwatch:GetMetricStream",
-          "cloudwatch:ListDashboards",
-          "cloudwatch:ListMetrics",
-          "ec2:DescribeAddresses",
-          "ec2:DescribeImages",
-          "ec2:DescribeInstances",
-          "ec2:DescribeInstanceStatus",
-          "ec2:DescribeInstanceTypes",
-          "ec2:DescribeKeyPairs",
-          "ec2:DescribeSecurityGroups",
-          "ec2:DescribeSecurityGroupRules",
-          "ec2:DescribeRegions",
-          "ecr:DescribeImages",
-          "ecr:DescribeRepositories",
-          "ecr:GetRegistryScanningConfiguration",
-          "ecr:ListImages",
-          "iam:ChangePassword",
-          "iam:GetAccountPasswordPolicy",
-          "iam:GetRole",
-          "iam:GetLoginProfile",
-          "iam:GetPolicy",
-          "iam:GetUser",
-          "iam:ListAccessKeys",
-          "iam:ListAttachedRolePolicies",
-          "iam:ListGroups",
-          "iam:ListGroupsForUser",
-          "iam:ListMFADevices",
-          "iam:ListPolicies",
-          "iam:ListRolePolicies",
-          "iam:ListRoles",
-          "iam:ListSigningCertificates",
-          "iam:ListUsers",
-          "lambda:GetAccountSettings",
-          "lambda:GetFunction",
-          "lambda:GetFunctionEventInvokeConfig",
-          "lambda:GetPolicy",
-          "lambda:ListAliases",
-          "lambda:ListEventSourceMappings",
-          "lambda:ListFunctions",
-          "lambda:ListFunctionUrlConfigs",
-          "lambda:ListProvisionedConcurrencyConfigs",
-          "lambda:ListTags",
-          "lambda:ListVersionsByFunction",
-          "s3:ListAllMyBuckets",
-          "s3:ListBucket",
-        ]
-        Effect   = "Allow"
-        Resource = "*"
-      }
-    ]
-  })
+  key  = "pgp-b64.key"
 }
 
 resource "aws_iam_user" "github_actions" {
@@ -171,11 +94,6 @@ resource "aws_iam_user_policy" "github_actions" {
       }
     ]
   })
-}
-
-resource "aws_iam_user_login_profile" "personal" {
-  user    = aws_iam_user.personal.name
-  pgp_key = file("keys/pgp-b64.key")
 }
 
 resource "aws_iam_user" "postgres_backups" {

--- a/terraform/modules/user/main.tf
+++ b/terraform/modules/user/main.tf
@@ -1,0 +1,85 @@
+locals {
+  key_path = format("keys/%s", var.key)
+}
+
+resource "aws_iam_user" "this" {
+  name = var.name
+}
+
+resource "aws_iam_access_key" "this" {
+  user    = aws_iam_user.this.name
+  pgp_key = file(local.key_path)
+}
+
+resource "aws_iam_user_policy" "this" {
+  name = format("%s.policy", aws_iam_user.this.name)
+  user = aws_iam_user.this.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "autoscaling:DescribeAutoScalingGroups",
+          "ce:GetCostAndUsage",
+          "ce:GetCostForecast",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:GetMetricStream",
+          "cloudwatch:ListDashboards",
+          "cloudwatch:ListMetrics",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeKeyPairs",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSecurityGroupRules",
+          "ec2:DescribeRegions",
+          "ecr:DescribeImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetRegistryScanningConfiguration",
+          "ecr:ListImages",
+          "iam:ChangePassword",
+          "iam:GetAccountPasswordPolicy",
+          "iam:GetRole",
+          "iam:GetLoginProfile",
+          "iam:GetPolicy",
+          "iam:GetUser",
+          "iam:ListAccessKeys",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListGroups",
+          "iam:ListGroupsForUser",
+          "iam:ListMFADevices",
+          "iam:ListPolicies",
+          "iam:ListRolePolicies",
+          "iam:ListRoles",
+          "iam:ListSigningCertificates",
+          "iam:ListUsers",
+          "lambda:GetAccountSettings",
+          "lambda:GetFunction",
+          "lambda:GetFunctionEventInvokeConfig",
+          "lambda:GetPolicy",
+          "lambda:ListAliases",
+          "lambda:ListEventSourceMappings",
+          "lambda:ListFunctions",
+          "lambda:ListFunctionUrlConfigs",
+          "lambda:ListProvisionedConcurrencyConfigs",
+          "lambda:ListTags",
+          "lambda:ListVersionsByFunction",
+          "s3:ListAllMyBuckets",
+          "s3:ListBucket",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_login_profile" "this" {
+  user    = aws_iam_user.this.name
+  pgp_key = file(local.key_path)
+}

--- a/terraform/modules/user/variables.tf
+++ b/terraform/modules/user/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  type        = string
+  description = "The name of the user (ie. user.name)"
+}
+
+variable "key" {
+  type        = string
+  description = "The PGP key to use for their account access"
+}


### PR DESCRIPTION
The Terraform for setting up a new user account can all be moved to a single file and made generic, to make it easier in case we ever need to make a new account.

This change:
* Refreshes the lockfile (removing the Digital Ocean provider)
* Moves the policies to a module
* Removes `sts:AssumRole` from `IACDeployer` for the personal account
