### PR TITLE
feat: remove IPv6 setup

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -159,17 +159,12 @@ resource "aws_iam_user_policy" "configuration_deployer" {
 # Virtual Private Cloud definition
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-
-  assign_generated_ipv6_cidr_block = true
 }
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.0.0.0/24"
-  ipv6_cidr_block   = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 0)
   availability_zone = "eu-west-1a"
-
-  assign_ipv6_address_on_creation = true
 }
 
 # Internet Gateway definition
@@ -192,8 +187,6 @@ module "primary" {
     ami       = "ami-0ab14756db2442499"
     vpc_id    = aws_vpc.main.id
     subnet_id = aws_subnet.main.id
-
-    ipv6_address_count = 0
   }
 
   configuration = {
@@ -215,8 +208,6 @@ module "secondary" {
     ami       = "ami-0ab14756db2442499"
     vpc_id    = aws_vpc.main.id
     subnet_id = aws_subnet.main.id
-
-    ipv6_address_count = 0
   }
 
   configuration = {

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -172,7 +172,6 @@ resource "aws_instance" "this" {
 
   vpc_security_group_ids = [aws_security_group.this.id]
   iam_instance_profile   = aws_iam_instance_profile.this.name
-  ipv6_address_count     = var.instance.ipv6_address_count
 
   metadata_options {
     # Since we'll be running containers, we need an extra hop

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -9,7 +9,6 @@ variable "instance" {
     vpc_id             = string
     subnet_id          = string
     type               = string
-    ipv6_address_count = number
   })
   description = "Parameters for the underlying EC2 instance"
 }


### PR DESCRIPTION
This is causing issues when adding security group rules to the database since it wants to recreate it for some reason. We can revisit this in the future (likely through a new VPC entirely).

This change:
* Removes the IPv6 configuration in various places
