### PR TITLE
feat: allow Postgres access

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -240,7 +240,7 @@ module "database" {
   }
 
   key_name         = aws_key_pair.main.key_name
-  permitted_access = [module.secondary.security_group_id]
+  permitted_access = [module.primary.security_group_id, module.secondary.security_group_id]
 }
 
 # Route table definitions


### PR DESCRIPTION
Now #186 has gone in, we can re-run #185 and hopefully not recreate the database (thus destroying it first).

This change:
* Allows Postgres traffic from the primary instance to the database
