### PR TITLE
feat: fix IPv6 removal

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -159,6 +159,8 @@ resource "aws_iam_user_policy" "configuration_deployer" {
 # Virtual Private Cloud definition
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
+
+  assign_generated_ipv6_cidr_block = true
 }
 
 resource "aws_subnet" "main" {


### PR DESCRIPTION
This is failing to apply at the moment since the VPC depends on the subnet (maybe, best guess).

This change:
* Reverts the change to the VPC first
