### PR TITLE
feat: destroy primary instance

### DIFF
--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -172,6 +172,7 @@ resource "aws_instance" "this" {
 
   vpc_security_group_ids = [aws_security_group.this.id]
   iam_instance_profile   = aws_iam_instance_profile.this.name
+  ipv6_address_count     = var.instance.ipv6_address_count
 
   metadata_options {
     # Since we'll be running containers, we need an extra hop

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -9,6 +9,7 @@ variable "instance" {
     vpc_id             = string
     subnet_id          = string
     type               = string
+    ipv6_address_count = number
   })
   description = "Parameters for the underlying EC2 instance"
 }


### PR DESCRIPTION
Terraform state is slightly muddled, let's get back to a clean representation of what's going on (hopefully).

This change:
* Destroys the primary instance which has an IPv6 address associated with it for some reason
