### PR TITLE
feat: remove IPv6 setup

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -166,10 +166,7 @@ resource "aws_vpc" "main" {
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.0.0.0/24"
-  ipv6_cidr_block   = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 0)
   availability_zone = "eu-west-1a"
-
-  assign_ipv6_address_on_creation = false
 }
 
 # Internet Gateway definition
@@ -192,8 +189,6 @@ module "secondary" {
     ami       = "ami-0ab14756db2442499"
     vpc_id    = aws_vpc.main.id
     subnet_id = aws_subnet.main.id
-
-    ipv6_address_count = 0
   }
 
   configuration = {

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -74,16 +74,6 @@ resource "aws_security_group_rule" "allow_inbound_ssh" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "allow_inbound_ipv6_ssh" {
-  description       = "Allow inbound SSH from anywhere on IPv6"
-  type              = "ingress"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  ipv6_cidr_blocks  = ["::/0"]
-}
-
 resource "aws_security_group_rule" "allow_inbound_https" {
   description       = "Allow inbound HTTPS from anywhere"
   type              = "ingress"
@@ -92,16 +82,6 @@ resource "aws_security_group_rule" "allow_inbound_https" {
   protocol          = "tcp"
   security_group_id = aws_security_group.this.id
   cidr_blocks       = ["0.0.0.0/0"]
-}
-
-resource "aws_security_group_rule" "allow_inbound_ipv6_https" {
-  description       = "Allow inbound HTTPS from anywhere on IPv6"
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  ipv6_cidr_blocks  = ["::/0"]
 }
 
 resource "aws_security_group_rule" "allow_outbound_ssh" {
@@ -172,7 +152,6 @@ resource "aws_instance" "this" {
 
   vpc_security_group_ids = [aws_security_group.this.id]
   iam_instance_profile   = aws_iam_instance_profile.this.name
-  ipv6_address_count     = var.instance.ipv6_address_count
 
   metadata_options {
     # Since we'll be running containers, we need an extra hop

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -9,7 +9,6 @@ variable "instance" {
     vpc_id             = string
     subnet_id          = string
     type               = string
-    ipv6_address_count = number
   })
   description = "Parameters for the underlying EC2 instance"
 }


### PR DESCRIPTION
The IPv6 setup isn't being used at the moment and will probably be revisited through an entire migration of the infrastructure. Let's remove it for now as it has been causing some problems.

This change:
* Removes it from the instances and subnet
