### PR TITLE
feat: remove autogenerated IPv6 CIDR

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -159,8 +159,6 @@ resource "aws_iam_user_policy" "configuration_deployer" {
 # Virtual Private Cloud definition
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-
-  assign_generated_ipv6_cidr_block = true
 }
 
 resource "aws_subnet" "main" {


### PR DESCRIPTION
The top-level VPC has an autogenerated IPv6 CIDR block which we're not longer using, so let's get rid of it.

This change:
* Removes the setting
