### PR TITLE
feat: bring up new instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -178,6 +178,27 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
+module "primary" {
+  source = "./modules/f2-instance"
+  name   = "primary"
+
+  instance = {
+    type      = "t2.nano"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20240406-1025"
+  }
+
+  key_name       = aws_key_pair.main.key_name
+  hosted_zone_id = aws_route53_zone.opentracker.id
+}
+
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "secondary"
@@ -220,6 +241,16 @@ module "database" {
 
   key_name         = aws_key_pair.main.key_name
   permitted_access = [module.secondary.security_group_id]
+}
+
+resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
+  description              = format("Allow inbound connections from %s", module.primary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
 }
 
 # Route table definitions

--- a/terraform/modules/postgres/outputs.tf
+++ b/terraform/modules/postgres/outputs.tf
@@ -1,0 +1,3 @@
+output "security_group_id" {
+  value = aws_security_group.this.id
+}


### PR DESCRIPTION
Having sorted out all the IPv6 drama (and working out a way to add the security group rule without a follow-up change), we can now create the new primary instance.

This change:
* Defines the instance
* Allows traffic to the Postgres instance
