### PR TITLE
feat: allow assigning EIPs for Postgres

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -220,6 +220,7 @@ module "database" {
 
   key_name         = aws_key_pair.main.key_name
   permitted_access = []
+  elastic_ip       = false
 }
 
 resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -155,3 +155,10 @@ resource "aws_volume_attachment" "this" {
   volume_id   = aws_ebs_volume.this.id
   instance_id = aws_instance.this.id
 }
+
+resource "aws_eip" "this" {
+  count = var.elastic_ip ? 1 : 0
+
+  instance = aws_instance.this.id
+  domain   = "vpc"
+}

--- a/terraform/modules/postgres/variables.tf
+++ b/terraform/modules/postgres/variables.tf
@@ -34,3 +34,8 @@ variable "permitted_access" {
   description = "The security group identifiers that are allowed to access the instance"
   default     = []
 }
+
+variable "elastic_ip" {
+  type        = bool
+  description = "Whether the instance should have an elastic IP associated with it"
+}


### PR DESCRIPTION
It's sometimes useful to be able to get onto the Postgres instance for debugging things like backups, so let's have a way of assigning an EIP for SSH access.

This change:
* Adds a variable, set to false
* Creates an EIP if the variable is true
