### PR TITLE
feat: add setup for `ticket-tracker`

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -71,6 +71,13 @@ module "personal" {
   key  = "pgp-b64.key"
 }
 
+module "repositories" {
+  source   = "./modules/repository"
+  for_each = toset(["ticket-tracker"])
+
+  name = each.key
+}
+
 resource "aws_iam_user" "github_actions" {
   name = "github.actions"
 }

--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -1,0 +1,40 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = "IMMUTABLE"
+}
+
+resource "aws_iam_user" "builder" {
+  name = format("%s-builder", var.name)
+}
+
+resource "aws_iam_access_key" "builder" {
+  user    = aws_iam_user.builder.name
+  pgp_key = file("keys/pgp-b64.key")
+}
+
+resource "aws_iam_user_policy" "builder" {
+  name = format("%s-policy", aws_iam_user.builder.name)
+  user = aws_iam_user.builder.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ecr:CompleteLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:InitiateLayerUpload",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage"
+        ]
+        Effect   = "Allow"
+        Resource = aws_ecr_repository.this.arn
+      },
+      {
+        Action   = ["ecr:GetAuthorizationToken"]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/modules/repository/variables.tf
+++ b/terraform/modules/repository/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  type        = string
+  description = "The name of the application"
+}


### PR DESCRIPTION
The new application is going to need to have images pushed over to ECR, so let's begin abstracting the whole "repository" concept so we can support multiple repositories with separate credentials for pushing to each.

This change:
* Adds a new module called `repository`
* Defines the `ticket-tracker` repository
