### PR TITLE
feat: support pulling images from ECR

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -202,6 +202,39 @@ module "primary" {
     image_tag = "20240406-1025"
   }
 
+  ecr = {
+    account_id = "558855412466"
+    region     = "eu-west-1"
+    repository = "ticket-tracker"
+  }
+
+  key_name       = aws_key_pair.main.key_name
+  hosted_zone_id = aws_route53_zone.opentracker.id
+}
+
+module "secondary" {
+  source = "./modules/f2-instance"
+  name   = "secondary"
+
+  instance = {
+    type      = "t2.nano"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20240406-1025"
+  }
+
+  ecr = {
+    account_id = "558855412466"
+    region     = "eu-west-1"
+    repository = "ticket-tracker"
+  }
+
   key_name       = aws_key_pair.main.key_name
   hosted_zone_id = aws_route53_zone.opentracker.id
 }

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 # Update existing list of packages and install some basic ones
 sudo apt update
-sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
+sudo apt install -y apt-transport-https ca-certificates curl software-properties-common awscli
 
 # Set up the Docker registry
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
@@ -14,5 +14,8 @@ sudo apt install -y docker-ce
 
 # Allow the `ubuntu` user to run `docker` commands (for SSH access)
 sudo usermod -aG docker ubuntu
+
+# Authenticate with ECR for pulling images
+aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${account_id}.dkr.ecr.${region}.amazonaws.com
 
 sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -p 443:443 alexanderjackson/f2:${tag} -- --config s3://${config_bucket}/${config_key}

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -5,10 +5,10 @@ variable "name" {
 
 variable "instance" {
   type = object({
-    ami                = string
-    vpc_id             = string
-    subnet_id          = string
-    type               = string
+    ami       = string
+    vpc_id    = string
+    subnet_id = string
+    type      = string
   })
   description = "Parameters for the underlying EC2 instance"
 }
@@ -20,6 +20,15 @@ variable "configuration" {
     image_tag = string
   })
   description = "Parameters for the underlying `f2` instance to use"
+}
+
+variable "ecr" {
+  type = object({
+    account_id = string
+    region     = string
+    repository = string
+  })
+  description = "Configuration for pulling images from ECR"
 }
 
 variable "key_name" {


### PR DESCRIPTION
Since `ticket-tracker` is defined as an ECR repository (and likely everything will be in the future), we'll need to allow the `f2-instance` module to pull images directly from there. This is actually more performant as well (since we're in the same region) so means starting new containers is a little quicker.

This change:
* Adds configuration to allow `f2-instance` resources to pull images from the `ticket-tracker` repository
* Updates the user data script to login to ECR on startup
* Sets the module to not restart on user data changes
* Creates a new instance so it has the new login flow
