### PR TITLE
feat: swap instance traffic

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -313,7 +313,7 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [module.primary.public_ip]
+  records = [module.secondary.public_ip]
 }
 
 resource "aws_route53_record" "opentracker_tags" {
@@ -321,5 +321,5 @@ resource "aws_route53_record" "opentracker_tags" {
   name    = "tags"
   type    = "A"
   ttl     = 300
-  records = [module.primary.public_ip]
+  records = [module.secondary.public_ip]
 }


### PR DESCRIPTION
The `secondary` instance is now up and healthy, so we can move the traffic over to it.

This change:
* Updates the DNS records
