### PR TITLE
refactor: remove permitted access

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -231,9 +231,8 @@ module "database" {
     configuration_bucket = module.config_bucket.name
   }
 
-  key_name         = aws_key_pair.main.key_name
-  permitted_access = []
-  elastic_ip       = false
+  key_name   = aws_key_pair.main.key_name
+  elastic_ip = false
 }
 
 resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -99,18 +99,6 @@ resource "aws_security_group_rule" "allow_outbound_https" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "allow_inbound_connections_from_instances" {
-  for_each = toset(var.permitted_access)
-
-  description              = format("Allow inbound connections from %s", each.value)
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = each.value
-  security_group_id        = aws_security_group.this.id
-}
-
 data "aws_subnet" "self" {
   id = var.instance.subnet_id
 }

--- a/terraform/modules/postgres/variables.tf
+++ b/terraform/modules/postgres/variables.tf
@@ -29,12 +29,6 @@ variable "key_name" {
   description = "The name of the `aws_key_pair` to use for the instance access"
 }
 
-variable "permitted_access" {
-  type        = list(string)
-  description = "The security group identifiers that are allowed to access the instance"
-  default     = []
-}
-
 variable "elastic_ip" {
   type        = bool
   description = "Whether the instance should have an elastic IP associated with it"


### PR DESCRIPTION
The permitted access property doesn't really work, since changing it causes the Postgres instance to be recreated. Instead, we're just configuring it outside the module with security group rules.

This change:
* Removes the variable and implementation
