### PR TITLE
feat: bring up new instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -185,6 +185,27 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
+module "primary" {
+  source = "./modules/f2-instance"
+  name   = "primary"
+
+  instance = {
+    type      = "t2.nano"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20240406-1025"
+  }
+
+  key_name       = aws_key_pair.main.key_name
+  hosted_zone_id = aws_route53_zone.opentracker.id
+}
+
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "secondary"
@@ -200,12 +221,6 @@ module "secondary" {
     bucket    = module.config_bucket.name
     key       = "f2/config.yaml"
     image_tag = "20240406-1025"
-  }
-
-  ecr = {
-    account_id = "558855412466"
-    region     = "eu-west-1"
-    repository = "ticket-tracker"
   }
 
   key_name       = aws_key_pair.main.key_name
@@ -233,6 +248,16 @@ module "database" {
 
   key_name   = aws_key_pair.main.key_name
   elastic_ip = false
+}
+
+resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
+  description              = format("Allow inbound connections from %s", module.primary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -34,25 +34,6 @@ resource "aws_iam_policy" "this" {
         Resource = format("arn:aws:s3:::%s/*", var.configuration.bucket)
       },
       {
-        Action   = ["ecr:GetAuthorizationToken"]
-        Effect   = "Allow"
-        Resource = "*"
-      },
-      {
-        Action = [
-          "ecr:BatchGetImage",
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:GetDownloadUrlForLayer"
-        ]
-        Effect = "Allow"
-        Resource = [format(
-          "arn:aws:ecr:%s:%s:repository/%s",
-          var.ecr.region,
-          var.ecr.account_id,
-          var.ecr.repository
-        )]
-      },
-      {
         Action   = ["route53:ListHostedZones", "route53:GetChange"]
         Effect   = "Allow"
         Resource = "*"
@@ -167,8 +148,6 @@ resource "aws_instance" "this" {
     tag           = var.configuration.image_tag
     config_bucket = var.configuration.bucket
     config_key    = var.configuration.key
-    account_id    = var.ecr.account_id
-    region        = var.ecr.region
   })
 
   vpc_security_group_ids = [aws_security_group.this.id]

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -15,7 +15,4 @@ sudo apt install -y docker-ce
 # Allow the `ubuntu` user to run `docker` commands (for SSH access)
 sudo usermod -aG docker ubuntu
 
-# Authenticate with ECR for pulling images
-aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${account_id}.dkr.ecr.${region}.amazonaws.com
-
 sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -p 443:443 alexanderjackson/f2:${tag} -- --config s3://${config_bucket}/${config_key}

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -22,15 +22,6 @@ variable "configuration" {
   description = "Parameters for the underlying `f2` instance to use"
 }
 
-variable "ecr" {
-  type = object({
-    account_id = string
-    region     = string
-    repository = string
-  })
-  description = "Configuration for pulling images from ECR"
-}
-
 variable "key_name" {
   type        = string
   description = "The name of the `aws_key_pair` to use for the instance access"


### PR DESCRIPTION
AWS has emailed to say that the current `f2` instance has had an underlying hardware failure and thus will be replaced in the near future. Let's get ahead of this and migrate it ourselves.

This change:
* Creates a new instance
