### PR TITLE
feat: switch traffic

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -300,7 +300,7 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [module.secondary.public_ip]
+  records = [module.primary.public_ip]
 }
 
 resource "aws_route53_record" "opentracker_tags" {
@@ -308,5 +308,5 @@ resource "aws_route53_record" "opentracker_tags" {
   name    = "tags"
   type    = "A"
   ttl     = 300
-  records = [module.secondary.public_ip]
+  records = [module.primary.public_ip]
 }


### PR DESCRIPTION
Once the new instance has come up and is healthy, we can swap the traffic over and tear down the old one. Turns out the previous release terminated the old instance for some reason so...

We can clean that up later, let's get the DNS swapped.

This change:
* Swaps the DNS records over
