### PR TITLE
feat: tear down secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -206,27 +206,6 @@ module "primary" {
   hosted_zone_id = aws_route53_zone.opentracker.id
 }
 
-module "secondary" {
-  source = "./modules/f2-instance"
-  name   = "secondary"
-
-  instance = {
-    type      = "t2.nano"
-    ami       = "ami-0ab14756db2442499"
-    vpc_id    = aws_vpc.main.id
-    subnet_id = aws_subnet.main.id
-  }
-
-  configuration = {
-    bucket    = module.config_bucket.name
-    key       = "f2/config.yaml"
-    image_tag = "20240406-1025"
-  }
-
-  key_name       = aws_key_pair.main.key_name
-  hosted_zone_id = aws_route53_zone.opentracker.id
-}
-
 module "database" {
   source = "./modules/postgres"
   name   = "database"
@@ -257,16 +236,6 @@ resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = module.primary.security_group_id
-  security_group_id        = module.database.security_group_id
-}
-
-resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
-  description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = module.secondary.security_group_id
   security_group_id        = module.database.security_group_id
 }
 


### PR DESCRIPTION
This is no longer serving any traffic (and seems to be stuck in a Pending state), so let's tear it down and stop spending the money on it.

This change:
* Removes the security group rule and instance
