### PR TITLE
feat: add `today` DNS record

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -279,3 +279,11 @@ resource "aws_route53_record" "opentracker_tags" {
   ttl     = 300
   records = [module.primary.public_ip]
 }
+
+resource "aws_route53_record" "opentracker_today" {
+  zone_id = aws_route53_zone.opentracker.id
+  name    = "today"
+  type    = "A"
+  ttl     = 300
+  records = [module.primary.public_ip]
+}


### PR DESCRIPTION
`today` has been launched on the instance and is being managed by `f2`, but there's no DNS record to actually route traffic to it.

This change:
* Adds a DNS record for it
