### PR TITLE
feat: bump `today`

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -72,7 +72,7 @@ services:
 
   today:
     image: alexanderjackson/today
-    tag: 20240819-1912
+    tag: 20240819-2007
     port: 8000
     replicas: 1
     host: today.opentracker.app


### PR DESCRIPTION
The old version is listening on `localhost` and thus not accepting any requests, whereas the new one is listening on the unspecified host and thus should allow incoming connections.

This change:
* Bumps the version
