### PR TITLE
chore: enable trace logging

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -87,3 +87,5 @@ services:
 
       DATABASE_HOST: 10.0.0.238
       DATABASE_PORT: 5432
+
+      RUST_LOG: trace


### PR DESCRIPTION
`today` doesn't seem to be doing anything, so let's enable trace logging so we get the most verbose output.

This change:
* Sets `RUST_LOG` to `trace`
