### PR TITLE
feat: create logging bucket

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -13,6 +13,11 @@ module "config_bucket" {
   bucket_name = "configuration"
 }
 
+module "logging_bucket" {
+  source      = "./modules/s3-bucket"
+  bucket_name = "logging"
+}
+
 resource "aws_iam_role" "iac_deployer" {
   name = "iac-deployer"
 
@@ -200,6 +205,10 @@ module "primary" {
     bucket    = module.config_bucket.name
     key       = "f2/config.yaml"
     image_tag = "20240406-1025"
+  }
+
+  logging = {
+    bucket = module.logging_bucket.name
   }
 
   key_name       = aws_key_pair.main.key_name

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -43,6 +43,16 @@ resource "aws_iam_policy" "this" {
         Effect   = "Allow"
         Resource = format("arn:aws:route53:::hostedzone/%s", var.hosted_zone_id)
       },
+      {
+        Action   = ["s3:ListBucket"]
+        Effect   = "Allow"
+        Resource = format("arn:aws:s3:::%s", var.logging.bucket)
+      },
+      {
+        Action   = ["s3:PutObject"]
+        Effect   = "Allow"
+        Resource = format("arn:aws:s3:::%s/*", var.logging.bucket)
+      },
     ]
   })
 }

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -22,6 +22,13 @@ variable "configuration" {
   description = "Parameters for the underlying `f2` instance to use"
 }
 
+variable "logging" {
+  type = object({
+    bucket = string
+  })
+  description = "Parameters for use in logging output"
+}
+
 variable "key_name" {
   type        = string
   description = "The name of the `aws_key_pair` to use for the instance access"


### PR DESCRIPTION
Currently, all the logs produced by the system are entirely ephemeral. To actually view anything, you need to go onto the instance and run `docker logs` presuming the container is still there.

Instead, we should be archiving all the logs to persistent storage such that they can be viewed historically if needed. This will also open up the ability to view them without being on the server hopefully.

The plan is to use `vector` for these and write them all to S3. A test instance (`secondary`) was spun up locally using `terraform apply` to test this and successfully created some log files from the Docker source into the bucket here.

This change:
* Creates the S3 bucket
* Gives `f2-instance` permissions on it
* Tears down the `secondary` instance
