### PR TITLE
feat: start `vector` on `f2` instances

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -215,6 +215,31 @@ module "primary" {
   hosted_zone_id = aws_route53_zone.opentracker.id
 }
 
+module "secondary" {
+  source = "./modules/f2-instance"
+  name   = "secondary"
+
+  instance = {
+    type      = "t2.nano"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20240406-1025"
+  }
+
+  logging = {
+    bucket = module.logging_bucket.name
+  }
+
+  key_name       = aws_key_pair.main.key_name
+  hosted_zone_id = aws_route53_zone.opentracker.id
+}
+
 module "database" {
   source = "./modules/postgres"
   name   = "database"
@@ -245,6 +270,16 @@ resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
+}
+
+resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
+  description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.secondary.security_group_id
   security_group_id        = module.database.security_group_id
 }
 

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -169,7 +169,9 @@ resource "aws_instance" "this" {
     http_put_response_hop_limit = 2
   }
 
-  user_data_replace_on_change = false
+  lifecycle {
+    ignore_changes = [user_data]
+  }
 }
 
 resource "aws_eip" "this" {

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -12,6 +12,10 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docke
 sudo apt update
 sudo apt install -y docker-ce
 
+# Download the `vector` configuration and get it running
+aws s3 cp s3://configuration-68f6c7/vector/vector.yaml /home/ubuntu/vector.yaml
+sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/vector.yaml:/etc/vector/vector.yaml timberio/vector:0.40.1-alpine
+
 # Allow the `ubuntu` user to run `docker` commands (for SSH access)
 sudo usermod -aG docker ubuntu
 


### PR DESCRIPTION
`vector` feels more like a foundational component, and we'll want it running on the instance before `f2` starts up so we can ensure we capture all the logs.

This change:
* Ignores lifecycle changes for `user_data` so instances don't restart or be replaced
* Adds a `secondary` instance with `vector` running on it
