### PR TITLE
feat: allow writing to backup bucket

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -211,6 +211,10 @@ module "secondary" {
     bucket = module.logging_bucket.name
   }
 
+  backups = {
+    bucket = module.postgres_backups_bucket.name
+  }
+
   key_name       = aws_key_pair.main.key_name
   hosted_zone_id = aws_route53_zone.opentracker.id
 }

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -53,6 +53,11 @@ resource "aws_iam_policy" "this" {
         Effect   = "Allow"
         Resource = format("arn:aws:s3:::%s/*", var.logging.bucket)
       },
+      {
+        Action   = ["s3:PutObject"]
+        Effect   = "Allow"
+        Resource = format("arn:aws:s3:::%s/*", var.backups.bucket)
+      },
     ]
   })
 }

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -29,6 +29,13 @@ variable "logging" {
   description = "Parameters for use in logging output"
 }
 
+variable "backups" {
+  type = object({
+    bucket = string
+  })
+  description = "Parameters for use in taking database backups"
+}
+
 variable "key_name" {
   type        = string
   description = "The name of the `aws_key_pair` to use for the instance access"


### PR DESCRIPTION
`pgbackup` is a rewrite of the existing database backup system that should hopefully be more observable and resiliant (without just relying on `cron` to do everything). It's going to need to write to the backup bucket, so let's allow it to do that.

This change:
* Allows the `f2-instance` profile to write to the Postgres backup bucket
