### PR TITLE
feat: bump `pgbackup`

### DIFF
--- a/f2/config.yaml
+++ b/f2/config.yaml
@@ -94,7 +94,7 @@ services:
 
   pgbackup:
     image: alexanderjackson/pgbackup
-    tag: 20240908-0628
+    tag: 20240908-0750
     port: 80
     replicas: 1
     host: unapplicable


### PR DESCRIPTION
This should get it running infinitely, which will help `f2` out a bit. Not sure if `f2` itself will implode when it tries to delete the old container which terminated, but let's find out...

This change:
* Bumps the version of `pgbackup`
