### PR TITLE
feat: support configurable `vector` versions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -208,7 +208,8 @@ module "secondary" {
   }
 
   logging = {
-    bucket = module.logging_bucket.name
+    bucket     = module.logging_bucket.name
+    vector_tag = "0.40.1-alpine"
   }
 
   backups = {

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -163,6 +163,7 @@ resource "aws_instance" "this" {
     tag           = var.configuration.image_tag
     config_bucket = var.configuration.bucket
     config_key    = var.configuration.key
+    vector_tag    = var.logging.vector_tag
   })
 
   vpc_security_group_ids = [aws_security_group.this.id]

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -14,7 +14,7 @@ sudo apt install -y docker-ce
 
 # Download the `vector` configuration and get it running
 aws s3 cp s3://configuration-68f6c7/vector/vector.yaml /home/ubuntu/vector.yaml
-sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/vector.yaml:/etc/vector/vector.yaml timberio/vector:0.40.1-alpine
+sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/vector.yaml:/etc/vector/vector.yaml timberio/vector:${vector_tag}
 
 # Allow the `ubuntu` user to run `docker` commands (for SSH access)
 sudo usermod -aG docker ubuntu

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -24,7 +24,8 @@ variable "configuration" {
 
 variable "logging" {
   type = object({
-    bucket = string
+    bucket     = string
+    vector_tag = string
   })
   description = "Parameters for use in logging output"
 }


### PR DESCRIPTION
There's a new version of `vector` available, but the current tag is hardcoded in the setup script for instances. We'll need to migrate traffic over to a new instance, but we can upgrade `f2` at the same time.

This change:
* Allows the `vector` version to be specified per instance
