### PR TITLE
feat: tear down secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -220,36 +220,6 @@ module "primary" {
   hosted_zone_id = aws_route53_zone.opentracker.id
 }
 
-module "secondary" {
-  source = "./modules/f2-instance"
-  name   = "secondary"
-
-  instance = {
-    type      = "t2.nano"
-    ami       = "ami-0ab14756db2442499"
-    vpc_id    = aws_vpc.main.id
-    subnet_id = aws_subnet.main.id
-  }
-
-  configuration = {
-    bucket    = module.config_bucket.name
-    key       = "f2/config.yaml"
-    image_tag = "20240406-1025"
-  }
-
-  logging = {
-    bucket     = module.logging_bucket.name
-    vector_tag = "0.40.1-alpine"
-  }
-
-  backups = {
-    bucket = module.postgres_backups_bucket.name
-  }
-
-  key_name       = aws_key_pair.main.key_name
-  hosted_zone_id = aws_route53_zone.opentracker.id
-}
-
 module "database" {
   source = "./modules/postgres"
   name   = "database"
@@ -280,16 +250,6 @@ resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = module.primary.security_group_id
-  security_group_id        = module.database.security_group_id
-}
-
-resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
-  description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = module.secondary.security_group_id
   security_group_id        = module.database.security_group_id
 }
 


### PR DESCRIPTION
The primary is now handling all the traffic and the DNS has flipped over, so let's tear this one down.

This change:
* Removes the instance and security group rule
