### PR TITLE
feat: swap instances over

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -190,9 +190,9 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
-module "primary" {
+module "secondary" {
   source = "./modules/f2-instance"
-  name   = "primary"
+  name   = "secondary"
 
   instance = {
     type      = "t2.nano"
@@ -243,13 +243,13 @@ module "database" {
   elastic_ip = false
 }
 
-resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
-  description              = format("Allow inbound connections from %s", module.primary.security_group_id)
+resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
+  description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
   type                     = "ingress"
   from_port                = 5432
   to_port                  = 5432
   protocol                 = "tcp"
-  source_security_group_id = module.primary.security_group_id
+  source_security_group_id = module.secondary.security_group_id
   security_group_id        = module.database.security_group_id
 }
 
@@ -283,7 +283,7 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [module.primary.public_ip]
+  records = [module.secondary.public_ip]
 }
 
 resource "aws_route53_record" "opentracker_tags" {
@@ -291,7 +291,7 @@ resource "aws_route53_record" "opentracker_tags" {
   name    = "tags"
   type    = "A"
   ttl     = 300
-  records = [module.primary.public_ip]
+  records = [module.secondary.public_ip]
 }
 
 resource "aws_route53_record" "opentracker_today" {
@@ -299,5 +299,5 @@ resource "aws_route53_record" "opentracker_today" {
   name    = "today"
   type    = "A"
   ttl     = 300
-  records = [module.primary.public_ip]
+  records = [module.secondary.public_ip]
 }


### PR DESCRIPTION
The current instance seemed to have degraded performance (significantly, considering it was unable to respond to requests entirely at times) despite the fact the CPU performance seemed alright and the database queries were running in sub-millisecond response times.

This has been failed over locally (due to lack of desire to make multiple PRs), so this will be a no-op.

This change:
* Swaps over to a new instance
