### PR TITLE
feat: tear down primary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -190,36 +190,6 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
-module "primary" {
-  source = "./modules/f2-instance"
-  name   = "primary"
-
-  instance = {
-    type      = "t2.nano"
-    ami       = "ami-0ab14756db2442499"
-    vpc_id    = aws_vpc.main.id
-    subnet_id = aws_subnet.main.id
-  }
-
-  configuration = {
-    bucket    = module.config_bucket.name
-    key       = "f2/config.yaml"
-    image_tag = "20241029-1119"
-  }
-
-  logging = {
-    bucket     = module.logging_bucket.name
-    vector_tag = "0.42.0-alpine"
-  }
-
-  backups = {
-    bucket = module.postgres_backups_bucket.name
-  }
-
-  key_name       = aws_key_pair.main.key_name
-  hosted_zone_id = aws_route53_zone.opentracker.id
-}
-
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "secondary"
@@ -271,16 +241,6 @@ module "database" {
 
   key_name   = aws_key_pair.main.key_name
   elastic_ip = false
-}
-
-resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
-  description              = format("Allow inbound connections from %s", module.primary.security_group_id)
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = module.primary.security_group_id
-  security_group_id        = module.database.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {


### PR DESCRIPTION
The secondary is handling all the traffic and should hopefully be more resiliant to network failures now.

This change:
* Tears down the primary
