### PR TITLE
feat: swap instances

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -190,6 +190,36 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
+module "primary" {
+  source = "./modules/f2-instance"
+  name   = "primary"
+
+  instance = {
+    type      = "t2.nano"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20241030-1356"
+  }
+
+  logging = {
+    bucket     = module.logging_bucket.name
+    vector_tag = "0.42.0-alpine"
+  }
+
+  backups = {
+    bucket = module.postgres_backups_bucket.name
+  }
+
+  key_name       = aws_key_pair.main.key_name
+  hosted_zone_id = aws_route53_zone.opentracker.id
+}
+
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "secondary"
@@ -243,6 +273,16 @@ module "database" {
   elastic_ip = false
 }
 
+resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
+  description              = format("Allow inbound connections from %s", module.primary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
+}
+
 resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
   description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
   type                     = "ingress"
@@ -283,7 +323,7 @@ resource "aws_route53_record" "opentracker" {
   name    = ""
   type    = "A"
   ttl     = 300
-  records = [module.secondary.public_ip]
+  records = [module.primary.public_ip]
 }
 
 resource "aws_route53_record" "opentracker_tags" {
@@ -291,7 +331,7 @@ resource "aws_route53_record" "opentracker_tags" {
   name    = "tags"
   type    = "A"
   ttl     = 300
-  records = [module.secondary.public_ip]
+  records = [module.primary.public_ip]
 }
 
 resource "aws_route53_record" "opentracker_today" {
@@ -299,5 +339,5 @@ resource "aws_route53_record" "opentracker_today" {
   name    = "today"
   type    = "A"
   ttl     = 300
-  records = [module.secondary.public_ip]
+  records = [module.primary.public_ip]
 }


### PR DESCRIPTION
The current instance is being very slow for some reason, potentially due to a noisy neighbour. Let's swap it to a separate instance and fail over the DNS (as generally it seems to come up quickly and it's largely unusable at the moment).

This change:
* Creates a new instance as a copy of the current one
* Allows it to connect to the database
* Swaps the DNS over
