### PR TITLE
feat: allow writes to Vector configuration

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -160,9 +160,12 @@ resource "aws_iam_user_policy" "configuration_deployer" {
         Resource = module.config_bucket.arn
       },
       {
-        Action   = ["s3:PutObject"]
-        Effect   = "Allow"
-        Resource = format("%s/f2/config.yaml", module.config_bucket.arn)
+        Action = ["s3:PutObject"]
+        Effect = "Allow"
+        Resource = [
+          format("%s/f2/config.yaml", module.config_bucket.arn),
+          format("%s/vector/vector.yaml", module.config_bucket.arn),
+        ]
       },
     ]
   })


### PR DESCRIPTION
Currently the configuration for `vector` is just placed in the S3 bucket and then read on startup. If it ever needs to be changed, it should be in source control.

This change:
* Allows the configuration deployer role to write it
