### PR TITLE
feat: allow writes for all `f2` configuration

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -163,7 +163,7 @@ resource "aws_iam_user_policy" "configuration_deployer" {
         Action = ["s3:PutObject"]
         Effect = "Allow"
         Resource = [
-          format("%s/f2/config.yaml", module.config_bucket.arn),
+          format("%s/f2/*.yaml", module.config_bucket.arn),
           format("%s/vector/vector.yaml", module.config_bucket.arn),
         ]
       },


### PR DESCRIPTION
The latest write failed, since the policy doesn't allow `mutual-tls.yaml` to be written. Since we're likely to add other YAML files in the future, let's allow all of them.

This change:
* Widens the policy to allow more writes
