### PR TITLE
feat: bring up secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -223,6 +223,36 @@ module "primary" {
   hosted_zone_id = aws_route53_zone.opentracker.id
 }
 
+module "secondary" {
+  source = "./modules/f2-instance"
+  name   = "secondary"
+
+  instance = {
+    type      = "t2.nano"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20241103-1822"
+  }
+
+  logging = {
+    bucket     = module.logging_bucket.name
+    vector_tag = "0.42.0-alpine"
+  }
+
+  backups = {
+    bucket = module.postgres_backups_bucket.name
+  }
+
+  key_name       = aws_key_pair.main.key_name
+  hosted_zone_id = aws_route53_zone.opentracker.id
+}
+
 module "database" {
   source = "./modules/postgres"
   name   = "database"
@@ -253,6 +283,16 @@ resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
+}
+
+resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
+  description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.secondary.security_group_id
   security_group_id        = module.database.security_group_id
 }
 


### PR DESCRIPTION
`f2` seems to be properly handling mTLS traffic now, so let's bring up a secondary instance for us to swap over.

This change:
* Creates a new instance
* Allows traffic to the database
