### PR TITLE
feat: add `uptime` records

### DIFF
--- a/configuration/f2/config.yaml
+++ b/configuration/f2/config.yaml
@@ -31,6 +31,15 @@ alb:
           location: s3
           bucket: configuration-68f6c7
           key: f2/certificates/today.opentracker.app/privkey.pem
+      uptime.opentracker.app:
+        cert_file:
+          location: s3
+          bucket: configuration-68f6c7
+          key: f2/certificates/uptime.opentracker.app/fullchain.pem
+        key_file:
+          location: s3
+          bucket: configuration-68f6c7
+          key: f2/certificates/uptime.opentracker.app/privkey.pem
   mtls:
     anchor:
       location: s3

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -304,3 +304,11 @@ resource "aws_route53_record" "opentracker_today" {
   ttl     = 300
   records = [module.secondary.public_ip]
 }
+
+resource "aws_route53_record" "opentracker_uptime" {
+  zone_id = aws_route53_zone.opentracker.id
+  name    = "uptime"
+  type    = "A"
+  ttl     = 300
+  records = [module.secondary.public_ip]
+}


### PR DESCRIPTION
Now that all the certificates have been rolled and there's one for `uptime`, we can define the DNS record and add it to the configuration for `f2` to use.

This change:
* Adds it to the configuration
* Defines a DNS record in Terraform
