### PR TITLE
feat: set force delete

### DIFF
--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -13,3 +13,9 @@ resource "aws_sns_topic_subscription" "outages" {
   protocol  = "email"
   endpoint  = "alexanderjackson@protonmail.com"
 }
+
+resource "aws_ecr_repository" "uptime" {
+  name                 = "uptime"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = true
+}


### PR DESCRIPTION
The apply for the last change failed as the repository still has images inside it and thus we need to set `force_delete` to true first.

This change:
* Re-adds the definition, but with `force_delete` enabled
