### PR TITLE
feat: delete ECR repository

### DIFF
--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -13,9 +13,3 @@ resource "aws_sns_topic_subscription" "outages" {
   protocol  = "email"
   endpoint  = "alexanderjackson@protonmail.com"
 }
-
-resource "aws_ecr_repository" "uptime" {
-  name                 = "uptime"
-  image_tag_mutability = "IMMUTABLE"
-  force_delete         = true
-}


### PR DESCRIPTION
Now that the repository has `force_delete` enabled, we should be able to delete it despite the fact it has images still inside.

This change:
* Removes the resource definition
