### PR TITLE
feat: allow publishing to SNS

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -219,6 +219,10 @@ module "secondary" {
     bucket = module.postgres_backups_bucket.name
   }
 
+  alerting = {
+    topic_arn = aws_sns_topic.outages.arn
+  }
+
   key_name       = aws_key_pair.main.key_name
   hosted_zone_id = aws_route53_zone.opentracker.id
 }

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -58,6 +58,11 @@ resource "aws_iam_policy" "this" {
         Effect   = "Allow"
         Resource = format("arn:aws:s3:::%s/*", var.backups.bucket)
       },
+      {
+        Action   = ["sns:Publish"]
+        Effect   = "Allow"
+        Resource = var.alerting.topic_arn
+      },
     ]
   })
 }

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -37,6 +37,13 @@ variable "backups" {
   description = "Parameters for use in taking database backups"
 }
 
+variable "alerting" {
+  type = object({
+    topic_arn = string
+  })
+  description = "Parameters for use in alerting for outages"
+}
+
 variable "key_name" {
   type        = string
   description = "The name of the `aws_key_pair` to use for the instance access"


### PR DESCRIPTION
The next version of `uptime` will publish alerts to SNS when it detects that a service has gone down, so it will need permissions to publish these notifications.

This change:
* Adds the permission to the instances
