### PR TITLE
feat: remove `uptime` bucket

### DIFF
--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -1,9 +1,3 @@
-module "bucket" {
-  source           = "./modules/s3-bucket"
-  bucket_name      = "uptime"
-  pending_deletion = true
-}
-
 resource "aws_sns_topic" "outages" {
   name = "outages"
 }


### PR DESCRIPTION
`uptime` now writes directly to Postgres instead of storing state in S3 and as such there's no need for this bucket. It's been marked for deletion for ages and the console reports that it is empty.

This change:
* Deletes the bucket
