### PR TITLE
feat: bring up `primary` instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -201,6 +201,44 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
+module "primary" {
+  source = "./modules/f2-instance"
+  name   = "primary"
+
+  instance = {
+    type      = "t3.nano"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20250109-0657"
+  }
+
+  logging = {
+    bucket     = module.logging_bucket.name
+    vector_tag = "0.46.1-alpine"
+  }
+
+  backups = {
+    bucket = module.postgres_backups_bucket.name
+  }
+
+  hackathon = {
+    bucket = module.hackathon_bucket.name
+  }
+
+  alerting = {
+    topic_arn = aws_sns_topic.outages.arn
+  }
+
+  key_name       = aws_key_pair.main.key_name
+  hosted_zone_id = aws_route53_zone.opentracker.id
+}
+
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "secondary"
@@ -215,7 +253,7 @@ module "secondary" {
   configuration = {
     bucket    = module.config_bucket.name
     key       = "f2/config.yaml"
-    image_tag = "20250109-0657"
+    image_tag = "20250511-1356"
   }
 
   logging = {
@@ -260,6 +298,16 @@ module "database" {
 
   key_name   = aws_key_pair.main.key_name
   elastic_ip = false
+}
+
+resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
+  description              = format("Allow inbound connections from %s", module.primary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {


### PR DESCRIPTION
We're upgrading the version of `f2` here, so it's probably worth checking that it actually works. There's also some assorted changes in here so definitely worth being careful.

This change:
* Brings up a new instance with a new version of `f2`
* Upgrades `vector` from `0.43.1` to `0.46.1`
* Swaps to a `t3.nano` over a `t2.micro`
