### PR TITLE
feat: allow modification of `forkup` domain

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -235,8 +235,11 @@ module "primary" {
     topic_arn = aws_sns_topic.outages.arn
   }
 
-  key_name       = aws_key_pair.main.key_name
-  hosted_zone_id = aws_route53_zone.opentracker.id
+  key_name = aws_key_pair.main.key_name
+  hosted_zones = [
+    aws_route53_zone.opentracker.id,
+    aws_route53_zone.forkup.id
+  ]
 }
 
 module "database" {

--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -41,7 +41,7 @@ resource "aws_iam_policy" "this" {
       {
         Action   = ["route53:ChangeResourceRecordSets"]
         Effect   = "Allow"
-        Resource = format("arn:aws:route53:::hostedzone/%s", var.hosted_zone_id)
+        Resource = formatlist("arn:aws:route53:::hostedzone/%s", var.hosted_zones)
       },
       {
         Action   = ["s3:ListBucket"]

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -56,7 +56,7 @@ variable "key_name" {
   description = "The name of the `aws_key_pair` to use for the instance access"
 }
 
-variable "hosted_zone_id" {
-  type        = string
-  description = "The hosted zone identifier for Let's Encrypt renewals"
+variable "hosted_zones" {
+  type        = list(string)
+  description = "The hosted zone identifiers for Let's Encrypt renewals"
 }


### PR DESCRIPTION
`forkup.app` is now managed by AWS, but we don't allow modifications to it so we can't generate certificates yet.

This change:
* Adds the additional permissions
