### PR TITLE
feat: switch traffic

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -368,7 +368,7 @@ resource "aws_route53_record" "records" {
   name    = each.key
   type    = "A"
   ttl     = 300
-  records = [module.secondary.public_ip]
+  records = [module.primary.public_ip]
 }
 
 resource "aws_route53_record" "forkup_records" {
@@ -380,5 +380,5 @@ resource "aws_route53_record" "forkup_records" {
   name    = each.key
   type    = "A"
   ttl     = 300
-  records = [module.secondary.public_ip]
+  records = [module.primary.public_ip]
 }


### PR DESCRIPTION
The `primary` instance is up and healthy, so let's flip the traffic over to it.

This change:
* Updates the DNS records to point to the new instance
