### PR TITLE
feat: add asynchronous analysis resources

### DIFF
--- a/terraform/forkup.tf
+++ b/terraform/forkup.tf
@@ -1,0 +1,18 @@
+resource "aws_sns_topic" "expense_analysis_completions" {
+  name = "expense-analysis-completions"
+}
+
+resource "aws_sqs_queue" "expense_analysis_completions" {
+  name = "expense-analysis-completions"
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sns_topic.expense_analysis_completions.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sns_topic_subscription" "expense_analysis_completions" {
+  topic_arn = aws_sns_topic.expense_analysis_completions.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.expense_analysis_completions.arn
+}

--- a/terraform/modules/user/main.tf
+++ b/terraform/modules/user/main.tf
@@ -95,7 +95,12 @@ resource "aws_iam_user_policy" "this" {
         Action = ["textract:AnalyzeExpense"]
         Effect   = "Allow"
         Resource = "*"
-      }
+      },
+      {
+        Action = ["sts:AssumeRole"]
+        Effect   = "Allow"
+        Resource = var.forkup_dev_role_arn
+      },
     ]
   })
 }

--- a/terraform/modules/user/variables.tf
+++ b/terraform/modules/user/variables.tf
@@ -12,3 +12,8 @@ variable "hackathon_bucket_name" {
   type        = string
   description = "The name of the bucket being used in the hackathon"
 }
+
+variable "forkup_dev_role_arn" {
+  type        = string
+  description = "The ARN of the forkup-dev role"
+}


### PR DESCRIPTION
In order to allow `forkup` to process expense analysis requests asynchronously, we need to use an SNS topic and SQS queue for Textract to put the results onto.

We'll also want some way to interact with this locally, so let's add a role we can assume that permits this.

This change:
* Adds the topic, queue and subscription
* Adds a `forkup-dev` role
* Allows users to assume it
