### PR TITLE
feat: remove erroneous resource

### DIFF
--- a/terraform/forkup.tf
+++ b/terraform/forkup.tf
@@ -4,11 +4,6 @@ resource "aws_sns_topic" "expense_analysis_completions" {
 
 resource "aws_sqs_queue" "expense_analysis_completions" {
   name = "expense-analysis-completions"
-
-  redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sns_topic.expense_analysis_completions.arn
-    maxReceiveCount     = 5
-  })
 }
 
 resource "aws_sns_topic_subscription" "expense_analysis_completions" {


### PR DESCRIPTION
The LLM generated this, but it cannot be done. `redrive_policy` must be routed to an SQS queue, not an SNS topic.

This change:
* Removes it for now
