### PR TITLE
fix: correct policy definitions

### DIFF
--- a/terraform/modules/user/output.tf
+++ b/terraform/modules/user/output.tf
@@ -1,0 +1,3 @@
+output "user_arn" {
+  value = aws_iam_user.this.arn
+}


### PR DESCRIPTION
This has been slightly botched, the `assume_role_policy` currently contains all the permissions but it should just define the users allowed to assume the role, with a separate `aws_iam_policy` and `aws_iam_role_policy_attachment` used to assign permissions.

This change:
* Corrects the code
