### PR TITLE
feat: add SQS permissions

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -235,6 +235,11 @@ resource "aws_iam_policy" "forkup_dev_policy" {
         Resource = aws_sns_topic.expense_analysis_completions.arn
       },
       {
+        Action   = "sqs:ReceiveMessage"
+        Effect   = "Allow"
+        Resource = aws_sqs_queue.expense_analysis_completions.arn
+      },
+      {
         Action   = "iam:PassRole"
         Effect   = "Allow"
         Resource = "*"


### PR DESCRIPTION
We're currently missing the SQS permissions, so we can't read from the queue.

This change:
* Allows the `forkup-dev` role to read from the queue
