### PR TITLE
feat: allow assuming various roles

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -197,7 +197,8 @@ resource "aws_iam_role" "forkup_dev" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          AWS = module.personal.user_arn
+          AWS     = module.personal.user_arn
+          Service = "textract.amazonaws.com"
         }
       }
     ]

--- a/terraform/modules/user/main.tf
+++ b/terraform/modules/user/main.tf
@@ -79,7 +79,7 @@ resource "aws_iam_user_policy" "this" {
         Resource = "arn:aws:s3:::logging-4acb18/*"
       },
       {
-        Action = ["s3:ListBucket"]
+        Action   = ["s3:ListBucket"]
         Effect   = "Allow"
         Resource = format("arn:aws:s3:::%s", var.hackathon_bucket_name)
       },
@@ -92,15 +92,20 @@ resource "aws_iam_user_policy" "this" {
         Resource = format("arn:aws:s3:::%s/*", var.hackathon_bucket_name)
       },
       {
-        Action = ["textract:AnalyzeExpense"]
+        Action   = ["textract:AnalyzeExpense"]
         Effect   = "Allow"
         Resource = "*"
       },
       {
-        Action = ["sts:AssumeRole"]
+        Action   = ["sts:AssumeRole"]
         Effect   = "Allow"
         Resource = var.forkup_dev_role_arn
       },
+      {
+        Action   = ["iam:PassRole"]
+        Effect   = "Allow"
+        Resource = var.forkup_dev_role_arn
+      }
     ]
   })
 }


### PR DESCRIPTION
We need to allow Textract to assume the `forkup-dev` role so it can publish items to the SNS topic, and we also need to allow the IAM user to pass through the role.

This change:
* Adds those permissions
