### PR TITLE
feat: trim permissions for configuration deployer

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -178,7 +178,7 @@ resource "aws_iam_user_policy" "configuration_deployer" {
         Action = ["s3:PutObject"]
         Effect = "Allow"
         Resource = [
-          format("%s/f2/*.yaml", module.config_bucket.arn),
+          format("%s/f2/config.yaml", module.config_bucket.arn),
           format("%s/f2/anchor.pem", module.config_bucket.arn),
           format("%s/vector/vector.yaml", module.config_bucket.arn),
         ]


### PR DESCRIPTION
The configuration deployer now only needs permissions to write the `config.yaml` file since there's no other YAML files for deployment at the moment.

This change:
* Tightens the permissions
