### PR TITLE
feat: allow writing `forkup` configuration

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -180,6 +180,7 @@ resource "aws_iam_user_policy" "configuration_deployer" {
         Resource = [
           format("%s/f2/config.yaml", module.config_bucket.arn),
           format("%s/f2/anchor.pem", module.config_bucket.arn),
+          format("%s/forkup/config.yaml", module.config_bucket.arn),
           format("%s/vector/vector.yaml", module.config_bucket.arn),
         ]
       },


### PR DESCRIPTION
The `forkup` backend configuration is going to be written as a separate file instead of environment variables and mounted to the container, so let's allow writing that from this repository.

This change:
* Adds additional permissions to the deployer
