### PR TITLE
feat: bring up `secondary` instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -78,7 +78,6 @@ locals {
   forkup_dev_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/forkup-dev"
 }
 
-# Add this at the top of your file
 data "aws_caller_identity" "current" {}
 
 module "personal" {
@@ -329,6 +328,47 @@ module "primary" {
   ]
 }
 
+module "secondary" {
+  source = "./modules/f2-instance"
+  name   = "secondary"
+
+  instance = {
+    type      = "t2.micro"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20250602-1718"
+  }
+
+  logging = {
+    bucket     = module.logging_bucket.name
+    vector_tag = "0.47.0-alpine"
+  }
+
+  backups = {
+    bucket = module.postgres_backups_bucket.name
+  }
+
+  hackathon = {
+    bucket = module.hackathon_bucket.name
+  }
+
+  alerting = {
+    topic_arn = aws_sns_topic.outages.arn
+  }
+
+  key_name = aws_key_pair.main.key_name
+  hosted_zones = [
+    aws_route53_zone.opentracker.id,
+    aws_route53_zone.forkup.id
+  ]
+}
+
 module "database" {
   source = "./modules/postgres"
   name   = "database"
@@ -359,6 +399,16 @@ resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
+}
+
+resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
+  description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.secondary.security_group_id
   security_group_id        = module.database.security_group_id
 }
 


### PR DESCRIPTION
`f2` has had some updates to allow mounting configuration as a volume (as well as bumping `mutual-tls` to remove some dependencies).

This change:
* Brings up a secondary instance with the new version
* Bumps the version of `vector`
