### PR TITLE
feat: teardown `primary` instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -287,47 +287,6 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
-module "primary" {
-  source = "./modules/f2-instance"
-  name   = "primary"
-
-  instance = {
-    type      = "t2.micro"
-    ami       = "ami-0ab14756db2442499"
-    vpc_id    = aws_vpc.main.id
-    subnet_id = aws_subnet.main.id
-  }
-
-  configuration = {
-    bucket    = module.config_bucket.name
-    key       = "f2/config.yaml"
-    image_tag = "20250515-1105"
-  }
-
-  logging = {
-    bucket     = module.logging_bucket.name
-    vector_tag = "0.46.1-alpine"
-  }
-
-  backups = {
-    bucket = module.postgres_backups_bucket.name
-  }
-
-  hackathon = {
-    bucket = module.hackathon_bucket.name
-  }
-
-  alerting = {
-    topic_arn = aws_sns_topic.outages.arn
-  }
-
-  key_name = aws_key_pair.main.key_name
-  hosted_zones = [
-    aws_route53_zone.opentracker.id,
-    aws_route53_zone.forkup.id
-  ]
-}
-
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "secondary"
@@ -390,16 +349,6 @@ module "database" {
 
   key_name   = aws_key_pair.main.key_name
   elastic_ip = false
-}
-
-resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
-  description              = format("Allow inbound connections from %s", module.primary.security_group_id)
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = module.primary.security_group_id
-  security_group_id        = module.database.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {


### PR DESCRIPTION
All the traffic has been swapped to the secondary instance, so we no longer need this one.

This change:
* Tears it down along with the associated security group rule
