### PR TITLE
feat: remove `forkup` record

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -395,8 +395,7 @@ resource "aws_route53_record" "records" {
     "", // root record
     "tags",
     "today",
-    "uptime",
-    "forkup"
+    "uptime"
   ])
 
   zone_id = aws_route53_zone.opentracker.id


### PR DESCRIPTION
`forkup.opentracker.app` is no longer needed as we have `forkup.app` registered instead. There's no valid certificate for the former anyway.

This change:
* Removes the DNS record
