### PR TITLE
feat: add internal DNS records

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -416,3 +416,16 @@ resource "aws_route53_record" "forkup_records" {
   ttl     = 300
   records = [module.secondary.public_ip]
 }
+
+# Internal Route 53 definitions
+resource "aws_route53_zone" "internal" {
+  name = "mesh.internal"
+}
+
+resource "aws_route53_record" "database" {
+  zone_id = aws_route53_zone.internal.id
+  name    = "postgres"
+  type    = "A"
+  ttl     = 300
+  records = [module.database.private_ip]
+}

--- a/terraform/modules/postgres/outputs.tf
+++ b/terraform/modules/postgres/outputs.tf
@@ -1,3 +1,7 @@
 output "security_group_id" {
   value = aws_security_group.this.id
 }
+
+output "private_ip" {
+  value = aws_instance.this.private_ip
+}


### PR DESCRIPTION
At the moment, each of the applications hardcode the IP address for the database. Instead, we should be relying on DNS to resolve this.

This change:
* Adds a `mesh.internal` zone
* Adds a `postgres.mesh.internal` record pointing to the database
