### PR TITLE
fix: make zone private

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -420,6 +420,10 @@ resource "aws_route53_record" "forkup_records" {
 # Internal Route 53 definitions
 resource "aws_route53_zone" "internal" {
   name = "mesh.internal"
+
+  vpc {
+    vpc_id = aws_vpc.main.id
+  }
 }
 
 resource "aws_route53_record" "database" {


### PR DESCRIPTION
This is currently not scoped to the VPC, so it's a public DNS record. `mesh.internal` isn't even a valid TLD I don't think and I certainly don't own it so it's not resolving on the instance.

This change:
* Scopes it to the VPC
