### PR TITLE
feat: bring up secondary instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -328,6 +328,47 @@ module "primary" {
   ]
 }
 
+module "secondary" {
+  source = "./modules/f2-instance"
+  name   = "primary"
+
+  instance = {
+    type      = "t2.micro"
+    ami       = "ami-0ab14756db2442499"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20250722-1814"
+  }
+
+  logging = {
+    bucket     = module.logging_bucket.name
+    vector_tag = "0.48.0-alpine"
+  }
+
+  backups = {
+    bucket = module.postgres_backups_bucket.name
+  }
+
+  hackathon = {
+    bucket = module.hackathon_bucket.name
+  }
+
+  alerting = {
+    topic_arn = aws_sns_topic.outages.arn
+  }
+
+  key_name = aws_key_pair.main.key_name
+  hosted_zones = [
+    aws_route53_zone.opentracker.id,
+    aws_route53_zone.forkup.id
+  ]
+}
+
 locals {
   telemetry_enabled = false
   f2_debug_enabled  = true
@@ -449,6 +490,16 @@ resource "aws_security_group_rule" "allow_inbound_connections_from_primary" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.database.security_group_id
+}
+
+resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
+  description              = format("Allow inbound connections from %s", module.secondary.security_group_id)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.secondary.security_group_id
   security_group_id        = module.database.security_group_id
 }
 


### PR DESCRIPTION
The current instance is trying to do networking, but it's on the `internal` network but not spawning containers into it.

This change:
* Brings up a new instance with the latest version of `f2` that does networking
