### PR TITLE
chore: remove debugging instance

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -330,7 +330,6 @@ module "secondary" {
 
 locals {
   telemetry_enabled = false
-  f2_debug_enabled  = true
 }
 
 module "telemetry" {
@@ -341,49 +340,6 @@ module "telemetry" {
 
   instance = {
     type      = "t2.medium"
-    ami       = "ami-0ab14756db2442499"
-    vpc_id    = aws_vpc.main.id
-    subnet_id = aws_subnet.main.id
-  }
-
-  configuration = {
-    bucket    = module.config_bucket.name
-    key       = "f2/telemetry.yaml"
-    image_tag = "20250722-1814"
-  }
-
-  logging = {
-    bucket     = module.logging_bucket.name
-    vector_tag = "0.48.0-alpine"
-  }
-
-  backups = {
-    bucket = module.postgres_backups_bucket.name
-  }
-
-  hackathon = {
-    bucket = module.hackathon_bucket.name
-  }
-
-  alerting = {
-    topic_arn = aws_sns_topic.outages.arn
-  }
-
-  key_name = aws_key_pair.main.key_name
-  hosted_zones = [
-    aws_route53_zone.opentracker.id,
-    aws_route53_zone.forkup.id
-  ]
-}
-
-module "f2_debug" {
-  count = local.f2_debug_enabled ? 1 : 0
-
-  source = "./modules/f2-instance"
-  name   = "f2-debug"
-
-  instance = {
-    type      = "t2.2xlarge"
     ami       = "ami-0ab14756db2442499"
     vpc_id    = aws_vpc.main.id
     subnet_id = aws_subnet.main.id
@@ -449,18 +405,6 @@ resource "aws_security_group_rule" "allow_inbound_connections_from_secondary" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = module.secondary.security_group_id
-  security_group_id        = module.database.security_group_id
-}
-
-resource "aws_security_group_rule" "allow_inbound_connections_from_f2_debug" {
-  count = local.f2_debug_enabled ? 1 : 0
-
-  description              = format("Allow inbound connections from %s", module.f2_debug[0].security_group_id)
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = module.f2_debug[0].security_group_id
   security_group_id        = module.database.security_group_id
 }
 


### PR DESCRIPTION
This instance is no longer required, we have fixed the underlying issue (which turned out to be a lack of the `/tmp` volume binding).

This change:
* Tears the instance down
