### PR TITLE
feat: add support for telemetry

### DIFF
--- a/terraform/modules/f2-instance/main.tf
+++ b/terraform/modules/f2-instance/main.tf
@@ -104,6 +104,23 @@ resource "aws_security_group_rule" "allow_inbound_ssh" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+data "aws_subnet" "inbound_http" {
+  count = var.inbound_http_subnet_id != null ? 1 : 0
+  id    = var.inbound_http_subnet_id
+}
+
+resource "aws_security_group_rule" "allow_inbound_http" {
+  count = var.inbound_http_subnet_id != null ? 1 : 0
+
+  description       = "Allow inbound http from the specified subnet"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  security_group_id = aws_security_group.this.id
+  cidr_blocks       = var.inbound_http_subnet_id != null ? [data.aws_subnet.inbound_http[0].cidr_block] : []
+}
+
 resource "aws_security_group_rule" "allow_inbound_https" {
   description       = "Allow inbound HTTPS from anywhere"
   type              = "ingress"

--- a/terraform/modules/f2-instance/outputs.tf
+++ b/terraform/modules/f2-instance/outputs.tf
@@ -5,3 +5,7 @@ output "public_ip" {
 output "security_group_id" {
   value = aws_security_group.this.id
 }
+
+output "private_ip" {
+  value = aws_instance.this.private_ip
+}

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -20,4 +20,4 @@ sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/
 sudo usermod -aG docker ubuntu
 
 sudo docker network create --driver bridge internal
-sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp --network internal -p 443:443 alexanderjackson/f2:${tag} -- --config s3://${config_bucket}/${config_key}
+sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp --network internal -p 80:80 -p 443:443 alexanderjackson/f2:${tag} -- --config s3://${config_bucket}/${config_key}

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -60,3 +60,9 @@ variable "hosted_zones" {
   type        = list(string)
   description = "The hosted zone identifiers for Let's Encrypt renewals"
 }
+
+variable "inbound_http_subnet_id" {
+  type        = string
+  description = "The subnet ID to allow inbound HTTP traffic from"
+  default     = null
+}


### PR DESCRIPTION
The `telemetry` instance runs ClickStack (or some of the components of it) and allows traces to be exported from the main `f2` instances into it. Additionally, it's exposed behind mTLS so we can poke around at the data.

This has already been applied locally through a lot of hacking around...

This change:
* Aligns the Terraform with what is actually being used
