### PR TITLE
feat: allow `tag-updater` configuration

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -181,6 +181,7 @@ resource "aws_iam_user_policy" "configuration_deployer" {
           format("%s/f2/telemetry.yaml", module.config_bucket.arn),
           format("%s/f2/anchor.pem", module.config_bucket.arn),
           format("%s/forkup/config.yaml", module.config_bucket.arn),
+          format("%s/tag-updater/config.yaml", module.config_bucket.arn),
           format("%s/vector/vector.yaml", module.config_bucket.arn),
         ]
       },


### PR DESCRIPTION
`tag-updater` will soon be able to use YAML-based configuration so let's update the policy to allow writing this.

This change:
* Allows `configuration/tag-updater/config.yaml` to be written to the S3 bucket by the deployer
