### PR TITLE
feat: add EBS volume

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -350,7 +350,7 @@ module "telemetry" {
   configuration = {
     bucket    = module.config_bucket.name
     key       = "f2/telemetry.yaml"
-    image_tag = "20250819-1953"
+    image_tag = "20250829-1918"
   }
 
   logging = {
@@ -368,6 +368,13 @@ module "telemetry" {
 
   alerting = {
     topic_arn = aws_sns_topic.outages.arn
+  }
+
+  extra_ebs_volume = {
+    size_gb     = 10
+    device_name = "/dev/sdf"
+    volume_type = "gp3"
+    encrypted   = true
   }
 
   key_name = aws_key_pair.main.key_name

--- a/terraform/modules/f2-instance/scripts/setup.sh
+++ b/terraform/modules/f2-instance/scripts/setup.sh
@@ -4,6 +4,64 @@
 sudo apt update
 sudo apt install -y apt-transport-https ca-certificates curl software-properties-common awscli
 
+# Handle extra EBS volume if configured
+if [ -n "${extra_volume_device}" ]; then
+    echo "Looking for extra EBS volume (specified as ${extra_volume_device})"
+
+    # On newer instance types, EBS volumes appear as NVMe devices
+    # Find the first unpartitioned NVMe device that's not the root volume
+    EBS_DEVICE=""
+    for device in /dev/nvme*n1; do
+        if [ -b "$device" ]; then
+            # Check if this device has partitions (root device will have partitions)
+            if ! lsblk "$device" | grep -q part; then
+                # Check if it's not already mounted
+                if ! mount | grep -q "$device"; then
+                    EBS_DEVICE="$device"
+                    echo "Found EBS volume at $EBS_DEVICE"
+                    break
+                fi
+            fi
+        fi
+    done
+
+    # Fallback to the originally specified device name
+    if [ -z "$EBS_DEVICE" ] && [ -b "${extra_volume_device}" ]; then
+        EBS_DEVICE="${extra_volume_device}"
+        echo "Using originally specified device ${extra_volume_device}"
+    fi
+
+    if [ -n "$EBS_DEVICE" ]; then
+        echo "Configuring extra EBS volume at $EBS_DEVICE"
+
+        # Check if the device is already formatted
+        if ! sudo blkid "$EBS_DEVICE"; then
+            echo "Formatting $EBS_DEVICE with ext4 filesystem"
+            sudo mkfs.ext4 -F "$EBS_DEVICE"
+        else
+            echo "Device $EBS_DEVICE is already formatted"
+        fi
+
+        # Create mount point and mount the volume directly to /mnt/data
+        sudo mkdir -p /mnt/data
+        sudo mount "$EBS_DEVICE" /mnt/data
+
+        # Add to fstab for persistent mounting (use UUID for reliability)
+        UUID=$(sudo blkid -s UUID -o value "$EBS_DEVICE")
+        if [ -n "$UUID" ] && ! grep -q "$UUID" /etc/fstab; then
+            echo "UUID=$UUID /mnt/data ext4 defaults,nofail 0 2" | sudo tee -a /etc/fstab
+        fi
+
+        # Set appropriate permissions for the mount point
+        sudo chown ubuntu:ubuntu /mnt/data
+        sudo chmod 755 /mnt/data
+
+        echo "Extra EBS volume configured and mounted directly at /mnt/data"
+    else
+        echo "Warning: No suitable EBS volume found"
+    fi
+fi
+
 # Set up the Docker registry
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -20,4 +78,4 @@ sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/
 sudo usermod -aG docker ubuntu
 
 sudo docker network create --driver bridge internal
-sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp --network internal -p 80:80 -p 443:443 alexanderjackson/f2:${tag} -- --config s3://${config_bucket}/${config_key}
+sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v /mnt:/mnt --network internal -p 80:80 -p 443:443 alexanderjackson/f2:${tag} -- --config s3://${config_bucket}/${config_key}

--- a/terraform/modules/f2-instance/variables.tf
+++ b/terraform/modules/f2-instance/variables.tf
@@ -66,3 +66,14 @@ variable "inbound_http_subnet_id" {
   description = "The subnet ID to allow inbound HTTP traffic from"
   default     = null
 }
+
+variable "extra_ebs_volume" {
+  type = object({
+    size_gb     = number
+    device_name = string
+    volume_type = optional(string, "gp3")
+    encrypted   = optional(bool, true)
+  })
+  description = "Configuration for an additional EBS volume"
+  default     = null
+}


### PR DESCRIPTION
The monitoring instance keeps running out of space as ClickHouse was storing data on the root filesystem and eventually consuming it. We also want this data to persist over restarts, so let's take a similar approach to the Postgres deployment and provision an EBS volume for it.

This change:
* Adds the ability to specify an EBS volume and mounts it
