### PR TITLE
feat: add permissions for `uptime`

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -183,6 +183,7 @@ resource "aws_iam_user_policy" "configuration_deployer" {
           format("%s/forkup/config.yaml", module.config_bucket.arn),
           format("%s/tag-updater/config.yaml", module.config_bucket.arn),
           format("%s/today/config.yaml", module.config_bucket.arn),
+          format("%s/uptime/config.yaml", module.config_bucket.arn),
           format("%s/vector/vector.yaml", module.config_bucket.arn),
         ]
       },


### PR DESCRIPTION
`uptime` is going to be imported into the monorepo and it would be good to define configuration for it, so let's allow that in the deployer.

This change:
* Adds additional permissions to allow deploying configuration for `uptime`
